### PR TITLE
feat: add bundle apply tool

### DIFF
--- a/tools/apply-bundle.mjs
+++ b/tools/apply-bundle.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+// Apply bundle.files.json → write files exactly, create directories, set exec bits for tools/*.mjs
+import fs from "fs";
+import path from "path";
+
+const bundlePath = process.argv[2] || "bundle.files.json";
+if (!fs.existsSync(bundlePath)) {
+  console.error(`Bundle not found at ${bundlePath}`);
+  process.exit(1);
+}
+const data = JSON.parse(fs.readFileSync(bundlePath, "utf8"));
+if (!data.files || typeof data.files !== "object") {
+  console.error("Invalid bundle: missing 'files' object");
+  process.exit(1);
+}
+
+for (const [p, content] of Object.entries(data.files)) {
+  const full = path.join(process.cwd(), p);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  const body = Array.isArray(content) ? content.join("\n") : String(content);
+  fs.writeFileSync(full, body, "utf8");
+  // mark executable scripts
+  if (p.startsWith("tools/") && p.endsWith(".mjs")) {
+    try { fs.chmodSync(full, 0o755); } catch {}
+  }
+  console.log("WROTE", p);
+}
+console.log("DONE");


### PR DESCRIPTION
## What changed?
- add apply-bundle script for expanding repository bundle

## Why?
- allow repo reconstruction from bundle for development

## Checks
- [ ] `nvm use && npm ci || npm install`
- [ ] `npm run validate` passes
- [ ] Lockfile updated if `package.json` changed
- [ ] No secrets added

Signed-off-by: Fred Egbuedike <fredilly@yahoo.com>

------
https://chatgpt.com/codex/tasks/task_e_68a59d119dc8833184ba94a18cc01b15