### PR TITLE
feat(audit): add scripts/core manifest and wire META. Recompute all hashes.

### DIFF
--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -12,3 +12,9 @@ jobs:
         run: |
           if git ls-files -z | xargs -0 file | grep -E 'CRLF|CR line'; then
             echo "Found CRLF endings"; exit 1; fi
+      - name: Verify scripts manifest
+        run: |
+          ./scripts/hash-scripts.sh > /tmp/scripts.sha
+          find scripts core -type f | sort > /tmp/actual
+          jq -r '.files[].path' scripts_manifest.json | sort > /tmp/manifest
+          diff -u /tmp/manifest /tmp/actual

--- a/RULESET.md
+++ b/RULESET.md
@@ -3,3 +3,12 @@
 - META must include audit_hashes.{sections_json_sha256,rules_json_sha256}.
 - Do not delete evidence; supersede only.
 - registry.json mirrors /methodologies.
+
+## Hash Policy Matrix
+
+| Artifact | Path Pattern | Hash Destination |
+| --- | --- | --- |
+| Methodology sections | methodologies/<ID>/sections.json | META.audit_hashes.sections_json_sha256 |
+| Methodology rules | methodologies/<ID>/rules.json | META.audit_hashes.rules_json_sha256 |
+| Tool resources | tools/<ID>/** | META.references.tools[] {path, sha256, kind} |
+| Repo scripts and core | scripts/**, core/** | scripts_manifest.json |

--- a/methodologies/TEMPLATE_METHOD/META.json
+++ b/methodologies/TEMPLATE_METHOD/META.json
@@ -4,6 +4,16 @@
     "rules_json_sha256": "79f6fee2de76d55457d44c501c43f09eeca7e930d57e3f5d3314657ab7161c73"
   },
   "references": {
-    "tools": []
+    "tools": [
+      {
+        "path": "tools/TEMPLATE_METHOD/source.pdf",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "kind": "pdf"
+      }
+    ]
+  },
+  "automation": {
+    "scripts_manifest_sha256": "b14fd32ef95ab10548c356a7ab0caf22b72675984614b3a59a34925c117bc58e",
+    "repo_commit": "1e6c85204148981a0e759e62a17b62a6ffe347cd"
   }
 }

--- a/scripts/hash-all.sh
+++ b/scripts/hash-all.sh
@@ -1,8 +1,40 @@
 #!/usr/bin/env bash
 set -euo pipefail
-j="methodologies/TEMPLATE_METHOD"
-s=$(node core/hashing/sha256.js "$j/sections.json")
-r=$(node core/hashing/sha256.js "$j/rules.json")
-tmp=$(mktemp)
-jq ".audit_hashes.sections_json_sha256=\"${s}\" | .audit_hashes.rules_json_sha256=\"${r}\"" \
-   "$j/META.json" > "$tmp" && mv "$tmp" "$j/META.json"
+
+cd "$(dirname "$0")/.."
+
+repo_commit=$(git rev-parse HEAD)
+
+scripts_manifest_sha=$(./scripts/hash-scripts.sh)
+
+for j in methodologies/*; do
+  [ -d "$j" ] || continue
+  id=$(basename "$j")
+  sections_hash=$(node core/hashing/sha256.js "$j/sections.json")
+  rules_hash=$(node core/hashing/sha256.js "$j/rules.json")
+
+  tools_dir="tools/$id"
+  tools_json="[]"
+  if [ -d "$tools_dir" ]; then
+    tools_json=$(find "$tools_dir" -type f | sort | while read -r f; do
+      sha=$(node core/hashing/sha256.js "$f")
+      kind="${f##*.}"
+      printf '{"path":"%s","sha256":"%s","kind":"%s"}\n' "$f" "$sha" "$kind"
+    done | jq -s '.')
+  fi
+
+  meta_file="$j/META.json"
+  tmp=$(mktemp)
+  jq \
+    --arg sections "$sections_hash" \
+    --arg rules "$rules_hash" \
+    --argjson tools "$tools_json" \
+    --arg manifest "$scripts_manifest_sha" \
+    --arg commit "$repo_commit" \
+    '.audit_hashes.sections_json_sha256 = $sections |
+     .audit_hashes.rules_json_sha256 = $rules |
+     .references.tools = $tools |
+     .automation = (.automation // {} | .scripts_manifest_sha256 = $manifest | .repo_commit = $commit)' \
+    "$meta_file" > "$tmp" && mv "$tmp" "$meta_file"
+
+done

--- a/scripts/hash-scripts.sh
+++ b/scripts/hash-scripts.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+set -eu
+
+# Navigate to repository root
+cd "$(dirname "$0")/.."
+
+# Collect files under scripts and core
+files=$(find scripts core -type f | sort)
+
+# Metadata
+generated_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+git_commit=$(git rev-parse HEAD)
+
+# Build files array
+entries=$(printf '%s\n' "$files" | while IFS= read -r f; do
+  sha=$(node core/hashing/sha256.js "$f")
+  printf '{"path":"%s","sha256":"%s"}\n' "$f" "$sha"
+done)
+
+printf '%s\n' "$entries" | jq -s --arg date "$generated_at" --arg commit "$git_commit" '{generated_at:$date, git_commit:$commit, files:.}' > scripts_manifest.json
+
+# Output manifest hash
+node core/hashing/sha256.js scripts_manifest.json

--- a/scripts_manifest.json
+++ b/scripts_manifest.json
@@ -1,0 +1,22 @@
+{
+  "generated_at": "2025-08-21T13:48:34Z",
+  "git_commit": "1e6c85204148981a0e759e62a17b62a6ffe347cd",
+  "files": [
+    {
+      "path": "core/hashing/sha256.js",
+      "sha256": "b4f9db6546461662be8652ea40f0619f2d10ee14987fb8e46b58b5c25d216738"
+    },
+    {
+      "path": "scripts/ci-run-tests.sh",
+      "sha256": "a197c80bfcac89797987b10bc6df5ce3f5540214a110058e89846559603efc24"
+    },
+    {
+      "path": "scripts/hash-all.sh",
+      "sha256": "71338e4b2f025b276b4ccf489a720c4315c331235d94ba10687ef9a80dbba19c"
+    },
+    {
+      "path": "scripts/hash-scripts.sh",
+      "sha256": "7d298c1971517a4fda76eb2f591d9bda7d2e3992a109987fae3c5f7529a07a8a"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- track hashes for scripts and core in scripts_manifest.json
- update hash-all automation to populate META and tool references
- verify scripts manifest in validate-json workflow

## Testing
- `./scripts/hash-scripts.sh`
- `./scripts/hash-all.sh`
- `node tests/schema-validate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7228f56a4833191ee80ef9077237c