### PR TITLE
TEMPLATE_METHOD schema; mark tools as kind 'tool'

### DIFF
--- a/methodologies/TEMPLATE_METHOD/META.json
+++ b/methodologies/TEMPLATE_METHOD/META.json
@@ -1,19 +1,19 @@
 {
   "audit_hashes": {
-    "sections_json_sha256": "a421952cc7f532b3d17c5e0d93bc803ebb774f917306f0b2b57783009ef985ac",
-    "rules_json_sha256": "79f6fee2de76d55457d44c501c43f09eeca7e930d57e3f5d3314657ab7161c73"
+    "rules_json_sha256": "79f6fee2de76d55457d44c501c43f09eeca7e930d57e3f5d3314657ab7161c73",
+    "sections_json_sha256": "a421952cc7f532b3d17c5e0d93bc803ebb774f917306f0b2b57783009ef985ac"
+  },
+  "automation": {
+    "repo_commit": "1ddd546f74906ce0d4d5f562bd6c935ca4854fdf",
+    "scripts_manifest_sha256": "513efb5f616e417c7b3a9833123f3416c1c5d921705b353f329d96d950ffb8ef"
   },
   "references": {
     "tools": [
       {
+        "kind": "tool",
         "path": "tools/TEMPLATE_METHOD/source.pdf",
-        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "kind": "pdf"
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       }
     ]
-  },
-  "automation": {
-    "scripts_manifest_sha256": "9f45970ab6f57d222109b878296ed0e1e3f38a531279d83bf9d10ba0d86b1c2d",
-    "repo_commit": "e275318d9babd558fe913ddfb9c8f4c320e03959"
   }
 }

--- a/scripts_manifest.json
+++ b/scripts_manifest.json
@@ -1,10 +1,11 @@
 {
-  "generated_at": "2025-08-21T14:04:59Z",
-  "git_commit": "e275318d9babd558fe913ddfb9c8f4c320e03959",
+  "generated_at": "2025-08-23T17:52:13Z",
+  "git_commit": "1ddd546f74906ce0d4d5f562bd6c935ca4854fdf",
   "files": [
     { "path": "core/hashing/sha256.js", "sha256": "b4f9db6546461662be8652ea40f0619f2d10ee14987fb8e46b58b5c25d216738" },
     { "path": "scripts/ci-run-tests.sh", "sha256": "a197c80bfcac89797987b10bc6df5ce3f5540214a110058e89846559603efc24" },
     { "path": "scripts/hash-all.sh", "sha256": "9b399464747405cf7a04f1c4fa3f7062d0c1a53b663a4860c4ea09a041212c21" },
-    { "path": "scripts/hash-scripts.sh", "sha256": "ee774cb19ed6f38c8edaeaa048d008e8759d512438946f7740ff79f79a7071a3" }
+    { "path": "scripts/hash-scripts.sh", "sha256": "ee774cb19ed6f38c8edaeaa048d008e8759d512438946f7740ff79f79a7071a3" },
+    { "path": "scripts/json-canonical-check.sh", "sha256": "369c2aba329b493666c768729b0c3b4c6395ecafd012788ba44cb82202e67099" }
   ]
 }


### PR DESCRIPTION
## WHAT
- Ensure META.json tool references use `kind: "tool"`
- Regenerate scripts manifest and automation hash

## WHY
- Satisfies schema requirement for tool entries and keeps manifest current

## TESTING
- `tail -n +2 scripts/json-canonical-check.sh | node` (non-canonical JSON in untouched files)
- `./scripts/ci-run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a9ffa095008331946f060ba1db19ca