### PR TITLE
METHOD_TEMPLATE template; add skeleton methodology

### DIFF
--- a/methodologies/METHOD_TEMPLATE/META.json
+++ b/methodologies/METHOD_TEMPLATE/META.json
@@ -15,3 +15,6 @@
         "sha256": "9d530f74b243d7e8f27437991152e4a2f4a581b0fb6873c115aec2ee54aa5867"
       }
     ]
+  },
+  "stage": "staging"
+}

--- a/methodologies/METHOD_TEMPLATE/META.json
+++ b/methodologies/METHOD_TEMPLATE/META.json
@@ -15,6 +15,3 @@
         "sha256": "9d530f74b243d7e8f27437991152e4a2f4a581b0fb6873c115aec2ee54aa5867"
       }
     ]
-  },
-  "stage": "staging"
-}

--- a/methodologies/METHOD_TEMPLATE/META.json
+++ b/methodologies/METHOD_TEMPLATE/META.json
@@ -1,0 +1,20 @@
+{
+  "audit_hashes": {
+    "rules_json_sha256": "a251bc761ee2aa979b12d0fe1015b14f4304cdaacad2fc2dddf3d74364ebaecf",
+    "sections_json_sha256": "c9962e30eec86b5273be09f6470a585f0fb67c6077f581f31b2711935a9da9b6"
+  },
+  "automation": {
+    "repo_commit": "dfa05c4530a75c79a2f74435353929458ddc2077",
+    "scripts_manifest_sha256": "c97c4f57aebeac6fbf21fd0fc826e580af9d2db17c6c0603448712822a616bee"
+  },
+  "references": {
+    "tools": [
+      {
+        "kind": "pdf",
+        "path": "tools/TEMPLATE_METHOD/source.pdf",
+        "sha256": "9d530f74b243d7e8f27437991152e4a2f4a581b0fb6873c115aec2ee54aa5867"
+      }
+    ]
+  },
+  "stage": "staging"
+}

--- a/methodologies/METHOD_TEMPLATE/rules.json
+++ b/methodologies/METHOD_TEMPLATE/rules.json
@@ -1,0 +1,11 @@
+{
+  "rules": [
+    {
+      "id": "R1",
+      "tags": [
+        "example"
+      ],
+      "text": "Example rule"
+    }
+  ]
+}

--- a/methodologies/METHOD_TEMPLATE/sections.json
+++ b/methodologies/METHOD_TEMPLATE/sections.json
@@ -1,0 +1,9 @@
+{
+  "sections": [
+    {
+      "content": "",
+      "id": "S1",
+      "title": "Scope"
+    }
+  ]
+}

--- a/tools/TEMPLATE_METHOD/source.pdf
+++ b/tools/TEMPLATE_METHOD/source.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+size 0


### PR DESCRIPTION
## Summary
- add METHOD_TEMPLATE with example sections and rules
- include META with audit hashes and an empty PDF reference

## Testing
- `./scripts/hash-all.sh`
- `./scripts/json-canonical-check.sh`
- `./scripts/ci-run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aaa93089888331a62307d680f94739