### PR TITLE
registry: generate canonical registry and enforce check

### DIFF
--- a/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
+++ b/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
@@ -4,15 +4,15 @@
     "sections_json_sha256": "c9962e30eec86b5273be09f6470a585f0fb67c6077f581f31b2711935a9da9b6"
   },
   "automation": {
-    "repo_commit": "2cee4133ed97fd0f1a554fb2f0adbd5a3caba35b",
-    "scripts_manifest_sha256": "0eecb706a89ca9f14f6ae4cecd7af0e31b6095d35750a22b22a83496b2ecd79b"
+    "repo_commit": "59b063af12c21a6d6c0adecaa4a45625b0516b5e",
+    "scripts_manifest_sha256": "8dbcb80bf4f7baf66cf69cf98fb344da3841f2a8ebe172bec68f63cd1026b511"
   },
   "references": {
     "tools": [
       {
+        "kind": "pdf",
         "path": "tools/GoldStandard/GS-00XX/v1-0/source.pdf",
-        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "kind": "pdf"
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       }
     ]
   }

--- a/methodologies/TEMPLATE_METHOD/META.json
+++ b/methodologies/TEMPLATE_METHOD/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "c9962e30eec86b5273be09f6470a585f0fb67c6077f581f31b2711935a9da9b6"
   },
   "automation": {
-    "repo_commit": "2cee4133ed97fd0f1a554fb2f0adbd5a3caba35b",
-    "scripts_manifest_sha256": "0eecb706a89ca9f14f6ae4cecd7af0e31b6095d35750a22b22a83496b2ecd79b"
+    "repo_commit": "59b063af12c21a6d6c0adecaa4a45625b0516b5e",
+    "scripts_manifest_sha256": "8dbcb80bf4f7baf66cf69cf98fb344da3841f2a8ebe172bec68f63cd1026b511"
   },
   "references": {
     "tools": []

--- a/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "2cee4133ed97fd0f1a554fb2f0adbd5a3caba35b",
-    "scripts_manifest_sha256": "0eecb706a89ca9f14f6ae4cecd7af0e31b6095d35750a22b22a83496b2ecd79b"
+    "repo_commit": "59b063af12c21a6d6c0adecaa4a45625b0516b5e",
+    "scripts_manifest_sha256": "8dbcb80bf4f7baf66cf69cf98fb344da3841f2a8ebe172bec68f63cd1026b511"
   },
   "dependencies": [
     {
@@ -28,19 +28,19 @@
   "references": {
     "tools": [
       {
+        "kind": "pdf",
         "path": "tools/UNFCCC/AR-AMS0003/v01-0/meth_booklet.pdf",
-        "sha256": "395e1dc00779cc5e580ad90c97c7d2189d3021f64e9c4b9ac4fabad3523ac69c",
-        "kind": "pdf"
+        "sha256": "395e1dc00779cc5e580ad90c97c7d2189d3021f64e9c4b9ac4fabad3523ac69c"
       },
       {
+        "kind": "docx",
         "path": "tools/UNFCCC/AR-AMS0003/v01-0/source.docx",
-        "sha256": "2719958c1e2b8c29613d13d043dea73f9dd3fb4edbd848a921b81734339ac4b1",
-        "kind": "docx"
+        "sha256": "2719958c1e2b8c29613d13d043dea73f9dd3fb4edbd848a921b81734339ac4b1"
       },
       {
+        "kind": "pdf",
         "path": "tools/UNFCCC/AR-AMS0003/v01-0/source.pdf",
-        "sha256": "4218a9dbf4c018f08a60c6564f532a336ba79cf7c782e32161c81d4d6a6427f2",
-        "kind": "pdf"
+        "sha256": "4218a9dbf4c018f08a60c6564f532a336ba79cf7c782e32161c81d4d6a6427f2"
       }
     ]
   },

--- a/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
@@ -4,45 +4,45 @@
     "sections_json_sha256": "c9962e30eec86b5273be09f6470a585f0fb67c6077f581f31b2711935a9da9b6"
   },
   "automation": {
-    "repo_commit": "2cee4133ed97fd0f1a554fb2f0adbd5a3caba35b",
-    "scripts_manifest_sha256": "0eecb706a89ca9f14f6ae4cecd7af0e31b6095d35750a22b22a83496b2ecd79b"
+    "repo_commit": "59b063af12c21a6d6c0adecaa4a45625b0516b5e",
+    "scripts_manifest_sha256": "8dbcb80bf4f7baf66cf69cf98fb344da3841f2a8ebe172bec68f63cd1026b511"
   },
   "references": {
     "tools": [
       {
+        "kind": "docx",
         "path": "tools/UNFCCC/AR-AMS0007/v03-1/source.docx",
-        "sha256": "2f73349cfc4630255319c6c8dfc1b46a8996ace9d14d8e07563b165915918ec2",
-        "kind": "docx"
+        "sha256": "2f73349cfc4630255319c6c8dfc1b46a8996ace9d14d8e07563b165915918ec2"
       },
       {
+        "kind": "pdf",
         "path": "tools/UNFCCC/AR-AMS0007/v03-1/source.pdf",
-        "sha256": "dc04ea2a039e27509db204bc6a7e3a5698308b2d578e1b86e43dc8ad12f4ad32",
-        "kind": "pdf"
+        "sha256": "dc04ea2a039e27509db204bc6a7e3a5698308b2d578e1b86e43dc8ad12f4ad32"
       },
       {
+        "kind": "pdf",
         "path": "tools/UNFCCC/AR-AMS0007/v03-1/tools/AR-TOOL08_v4-0-0.pdf",
-        "sha256": "e35cf86dbd5db6a81551d333d44274d54002973fb12d32095bdff6f1c5c5ccbb",
-        "kind": "pdf"
+        "sha256": "e35cf86dbd5db6a81551d333d44274d54002973fb12d32095bdff6f1c5c5ccbb"
       },
       {
+        "kind": "pdf",
         "path": "tools/UNFCCC/AR-AMS0007/v03-1/tools/AR-TOOL12_v3-1.pdf",
-        "sha256": "5aeffca3cfe52a173830b000bb3b713fcbaad519676998bf0b4e31e69effd216",
-        "kind": "pdf"
+        "sha256": "5aeffca3cfe52a173830b000bb3b713fcbaad519676998bf0b4e31e69effd216"
       },
       {
+        "kind": "pdf",
         "path": "tools/UNFCCC/AR-AMS0007/v03-1/tools/AR-TOOL14_v4-2.pdf",
-        "sha256": "dea000078bf02005f4a9852d06295a0800ad666f05971615916a38e08aea04ee",
-        "kind": "pdf"
+        "sha256": "dea000078bf02005f4a9852d06295a0800ad666f05971615916a38e08aea04ee"
       },
       {
+        "kind": "pdf",
         "path": "tools/UNFCCC/AR-AMS0007/v03-1/tools/AR-TOOL15_v2-0.pdf",
-        "sha256": "cae1080a443975b63c7ffb7517225d371e2088124c3628d479158f470bb63bce",
-        "kind": "pdf"
+        "sha256": "cae1080a443975b63c7ffb7517225d371e2088124c3628d479158f470bb63bce"
       },
       {
+        "kind": "pdf",
         "path": "tools/UNFCCC/AR-AMS0007/v03-1/tools/AR-TOOL16_v1-1-0.pdf",
-        "sha256": "92829e89d3893c6f5eb74075b681963492d256db69589d2878e5b8ba91cc64b6",
-        "kind": "pdf"
+        "sha256": "92829e89d3893c6f5eb74075b681963492d256db69589d2878e5b8ba91cc64b6"
       }
     ]
   },

--- a/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
@@ -4,15 +4,15 @@
     "sections_json_sha256": "c9962e30eec86b5273be09f6470a585f0fb67c6077f581f31b2711935a9da9b6"
   },
   "automation": {
-    "repo_commit": "2cee4133ed97fd0f1a554fb2f0adbd5a3caba35b",
-    "scripts_manifest_sha256": "0eecb706a89ca9f14f6ae4cecd7af0e31b6095d35750a22b22a83496b2ecd79b"
+    "repo_commit": "59b063af12c21a6d6c0adecaa4a45625b0516b5e",
+    "scripts_manifest_sha256": "8dbcb80bf4f7baf66cf69cf98fb344da3841f2a8ebe172bec68f63cd1026b511"
   },
   "references": {
     "tools": [
       {
+        "kind": "pdf",
         "path": "tools/Verra/VM0007/v1-6/source.pdf",
-        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "kind": "pdf"
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
       }
     ]
   }

--- a/registry.json
+++ b/registry.json
@@ -5,7 +5,17 @@
     "code": "GS-00XX",
     "version": "1.0",
     "path": "methodologies/GoldStandard/LUF/GS-00XX/v1-0",
-    "stage": "staging"
+    "stage": "staging",
+    "latest": true
+  },
+  {
+    "standard": "UNFCCC",
+    "program": "Forestry",
+    "code": "AR-AMS0003",
+    "version": "01.0",
+    "path": "methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0",
+    "stage": "staging",
+    "latest": true
   },
   {
     "standard": "UNFCCC",
@@ -13,7 +23,8 @@
     "code": "AR-AMS0007",
     "version": "03.1",
     "path": "methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1",
-    "stage": "staging"
+    "stage": "staging",
+    "latest": true
   },
   {
     "standard": "Verra",
@@ -21,6 +32,7 @@
     "code": "VM0007",
     "version": "1.6",
     "path": "methodologies/Verra/AFOLU/VM0007/v1-6",
-    "stage": "staging"
+    "stage": "staging",
+    "latest": true
   }
 ]

--- a/scripts/check-registry.sh
+++ b/scripts/check-registry.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+cd "$(dirname "$0")/.."
+node scripts/gen-registry.js
+git diff --quiet registry.json
+

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
+./scripts/check-registry.sh
 ./scripts/validate-offline.sh
+

--- a/scripts/gen-registry.js
+++ b/scripts/gen-registry.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.join(__dirname, '..');
+const baseDir = path.join(repoRoot, 'methodologies');
+
+function versionCompare(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pa[i] || 0) - (pb[i] || 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+const entries = [];
+const standards = fs.readdirSync(baseDir).sort();
+for (const standard of standards) {
+  const standardDir = path.join(baseDir, standard);
+  if (!fs.statSync(standardDir).isDirectory()) continue;
+  const programs = fs.readdirSync(standardDir).sort();
+  for (const program of programs) {
+    const programDir = path.join(standardDir, program);
+    if (!fs.statSync(programDir).isDirectory()) continue;
+    const codes = fs.readdirSync(programDir).sort();
+    for (const code of codes) {
+      const codeDir = path.join(programDir, code);
+      if (!fs.statSync(codeDir).isDirectory()) continue;
+      const versions = fs.readdirSync(codeDir).sort();
+      for (const vDir of versions) {
+        const fullPath = path.join(codeDir, vDir);
+        if (!fs.statSync(fullPath).isDirectory()) continue;
+        const metaFile = path.join(fullPath, 'META.json');
+        if (!fs.existsSync(metaFile)) continue;
+        const meta = JSON.parse(fs.readFileSync(metaFile, 'utf8'));
+        const stage = meta.stage || 'staging';
+        const version = vDir.slice(1).replace(/-/g, '.');
+        const relPath = path.relative(repoRoot, fullPath).split(path.sep).join('/');
+        entries.push({ standard, program, code, version, path: relPath, stage });
+      }
+    }
+  }
+}
+
+// mark latest per (standard, program, code)
+const groups = new Map();
+for (const e of entries) {
+  const key = `${e.standard}||${e.program}||${e.code}`;
+  if (!groups.has(key)) groups.set(key, []);
+  groups.get(key).push(e);
+}
+for (const arr of groups.values()) {
+  arr.sort((a, b) => versionCompare(a.version, b.version));
+  arr.forEach(x => (x.latest = false));
+  arr[arr.length - 1].latest = true;
+}
+
+entries.sort((a, b) =>
+  a.standard.localeCompare(b.standard) ||
+  a.program.localeCompare(b.program) ||
+  a.code.localeCompare(b.code) ||
+  versionCompare(a.version, b.version)
+);
+
+const outPath = path.join(repoRoot, 'registry.json');
+fs.writeFileSync(outPath, JSON.stringify(entries, null, 2) + '\n');
+

--- a/scripts_manifest.json
+++ b/scripts_manifest.json
@@ -1,10 +1,12 @@
 {
-  "generated_at": "2025-08-25T17:57:54Z",
-  "git_commit": "2cee4133ed97fd0f1a554fb2f0adbd5a3caba35b",
+  "generated_at": "2025-08-26T08:26:34Z",
+  "git_commit": "59b063af12c21a6d6c0adecaa4a45625b0516b5e",
   "files": [
     { "path": "core/hashing/sha256.js", "sha256": "b4f9db6546461662be8652ea40f0619f2d10ee14987fb8e46b58b5c25d216738" },
-    { "path": "scripts/ci-run-tests.sh", "sha256": "019cf26f169679c0eb9b7e2ea7ca507d80f3e1783ab784d1a2324cb5c8ea440a" },
+    { "path": "scripts/check-registry.sh", "sha256": "b1d6193aed8960eb7daa1bb57fef53803a416af4cf8ca576ce86a2579b61e287" },
+    { "path": "scripts/ci-run-tests.sh", "sha256": "ff8b0af04c33f9548ac6db2ba65e17fdc93b14d1c9e74b70277e6783835e45a5" },
     { "path": "scripts/compile-audit.js", "sha256": "dcf9417345c373c9ad26a7ee8d7cf27eaceb32daf1ca4ac398fd835d1f80de53" },
+    { "path": "scripts/gen-registry.js", "sha256": "ed5e27b27860ae358c20c1d0e2cd15c678cd021a50ef295ff0234603f00c8b0e" },
     { "path": "scripts/hash-all.sh", "sha256": "c0460b405ce03814872fb636c5eb8975bf6715b47c5bd0dee9353d1399d22ddb" },
     { "path": "scripts/hash-scripts.sh", "sha256": "ee774cb19ed6f38c8edaeaa048d008e8759d512438946f7740ff79f79a7071a3" },
     { "path": "scripts/install-vendored-ajv.sh", "sha256": "4a486815bc96c96bda8f4776b816bf79f2157e363f4f75a4a9bd250c342090bf" },


### PR DESCRIPTION
## WHAT
Adds a generator to produce a canonical `registry.json`, adds a drift check wired into `ci-run-tests.sh`, and rebuilds the registry with updated script hashes.

## WHY
Ensures registry entries are deterministic and causes CI to fail if the registry falls out of sync.

------
https://chatgpt.com/codex/tasks/task_e_68ad6f454a688331b18bf65a38624500