### PR TITLE
repo tests; add AJV fixture validation

### DIFF
--- a/tests/fixtures/sections.invalid.json
+++ b/tests/fixtures/sections.invalid.json
@@ -1,0 +1,8 @@
+{
+  "sections": [
+    {
+      "content": "text",
+      "id": "intro"
+    }
+  ]
+}

--- a/tests/fixtures/sections.valid.json
+++ b/tests/fixtures/sections.valid.json
@@ -1,0 +1,9 @@
+{
+  "sections": [
+    {
+      "content": "text",
+      "id": "intro",
+      "title": "Introduction"
+    }
+  ]
+}

--- a/tests/schema-validate.test.js
+++ b/tests/schema-validate.test.js
@@ -1,2 +1,20 @@
-// placeholder so CI can run a node-based check later
-console.log("ok");
+const test = require('node:test');
+const assert = require('node:assert');
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const runAjv = path.join(ROOT, 'scripts', 'run-ajv.sh');
+const schema = path.join(ROOT, 'schemas', 'sections.schema.json');
+const validFixture = path.join(__dirname, 'fixtures', 'sections.valid.json');
+const invalidFixture = path.join(__dirname, 'fixtures', 'sections.invalid.json');
+
+test('valid sections.json passes schema validation', () => {
+  execFileSync(runAjv, ['validate', '-s', schema, '-d', validFixture]);
+});
+
+test('invalid sections.json fails schema validation', () => {
+  assert.throws(() => {
+    execFileSync(runAjv, ['validate', '-s', schema, '-d', invalidFixture]);
+  });
+});


### PR DESCRIPTION
## WHAT
- replace placeholder test with run-ajv.sh validation
- add valid and invalid `sections.json` fixtures

## WHY
- demonstrate ajv passes for valid JSON and fails for schema violations


------
https://chatgpt.com/codex/tasks/task_e_68adfd22fdbc8331bd55e3029de908d9