### PR TITLE
multi-method meta; canonical JSON ordering

### DIFF
--- a/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
+++ b/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "c9962e30eec86b5273be09f6470a585f0fb67c6077f581f31b2711935a9da9b6"
   },
   "automation": {
-    "repo_commit": "166728fefd026ba637fd040f4ed8cae8a162e3c4",
-    "scripts_manifest_sha256": "c4bd7474df5ad6acdf0918a1b76765b51906e742c4816327f0b4da919090908d"
+    "repo_commit": "3eddc5cd9a0c1d4de3eea090454178f9502f13fb",
+    "scripts_manifest_sha256": "cf7c678e10d1e01c042e5b911f7cc7ac8af6d817ebb9618bd8fa53cebdf424ab"
   },
   "references": {
     "tools": [

--- a/methodologies/TEMPLATE_METHOD/META.json
+++ b/methodologies/TEMPLATE_METHOD/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "c9962e30eec86b5273be09f6470a585f0fb67c6077f581f31b2711935a9da9b6"
   },
   "automation": {
-    "repo_commit": "166728fefd026ba637fd040f4ed8cae8a162e3c4",
-    "scripts_manifest_sha256": "c4bd7474df5ad6acdf0918a1b76765b51906e742c4816327f0b4da919090908d"
+    "repo_commit": "3eddc5cd9a0c1d4de3eea090454178f9502f13fb",
+    "scripts_manifest_sha256": "cf7c678e10d1e01c042e5b911f7cc7ac8af6d817ebb9618bd8fa53cebdf424ab"
   },
   "references": {
     "tools": []

--- a/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "166728fefd026ba637fd040f4ed8cae8a162e3c4",
-    "scripts_manifest_sha256": "c4bd7474df5ad6acdf0918a1b76765b51906e742c4816327f0b4da919090908d"
+    "repo_commit": "3eddc5cd9a0c1d4de3eea090454178f9502f13fb",
+    "scripts_manifest_sha256": "cf7c678e10d1e01c042e5b911f7cc7ac8af6d817ebb9618bd8fa53cebdf424ab"
   },
   "dependencies": [
     {

--- a/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "c9962e30eec86b5273be09f6470a585f0fb67c6077f581f31b2711935a9da9b6"
   },
   "automation": {
-    "repo_commit": "166728fefd026ba637fd040f4ed8cae8a162e3c4",
-    "scripts_manifest_sha256": "c4bd7474df5ad6acdf0918a1b76765b51906e742c4816327f0b4da919090908d"
+    "repo_commit": "3eddc5cd9a0c1d4de3eea090454178f9502f13fb",
+    "scripts_manifest_sha256": "cf7c678e10d1e01c042e5b911f7cc7ac8af6d817ebb9618bd8fa53cebdf424ab"
   },
   "references": {
     "tools": [

--- a/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "c9962e30eec86b5273be09f6470a585f0fb67c6077f581f31b2711935a9da9b6"
   },
   "automation": {
-    "repo_commit": "166728fefd026ba637fd040f4ed8cae8a162e3c4",
-    "scripts_manifest_sha256": "c4bd7474df5ad6acdf0918a1b76765b51906e742c4816327f0b4da919090908d"
+    "repo_commit": "3eddc5cd9a0c1d4de3eea090454178f9502f13fb",
+    "scripts_manifest_sha256": "cf7c678e10d1e01c042e5b911f7cc7ac8af6d817ebb9618bd8fa53cebdf424ab"
   },
   "references": {
     "tools": [

--- a/scripts/json-canonical-fix.js
+++ b/scripts/json-canonical-fix.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const fs = require('fs'), path = require('path');
+function sortDeep(o){ if(Array.isArray(o)) return o.map(sortDeep);
+  if(o && typeof o==='object'){ return Object.keys(o).sort()
+    .reduce((a,k)=> (a[k]=sortDeep(o[k]), a),{}); }
+  return o; }
+function walk(dir){ for(const e of fs.readdirSync(dir,{withFileTypes:true})){
+  const p = path.join(dir,e.name);
+  if(e.isDirectory()) walk(p);
+  else if(e.isFile() && e.name==='META.json'){
+    const raw = fs.readFileSync(p,'utf8'); const data = JSON.parse(raw);
+    const out = JSON.stringify(sortDeep(data), null, 2) + '\n';
+    if(out !== raw){ fs.writeFileSync(p, out, 'utf8'); console.log('fixed', p); }
+  } } }
+walk(path.resolve('methodologies'));

--- a/scripts_manifest.json
+++ b/scripts_manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2025-08-27T06:44:43Z",
-  "git_commit": "166728fefd026ba637fd040f4ed8cae8a162e3c4",
+  "generated_at": "2025-08-27T15:16:29Z",
+  "git_commit": "3eddc5cd9a0c1d4de3eea090454178f9502f13fb",
   "files": [
     { "path": "core/hashing/sha256.js", "sha256": "b4f9db6546461662be8652ea40f0619f2d10ee14987fb8e46b58b5c25d216738" },
     { "path": "scripts/check-registry.sh", "sha256": "d66f360cfc7350e5056a81825c2a6aeb3edea448487d2c89829799d64ea2f968" },
@@ -11,6 +11,7 @@
     { "path": "scripts/hash-scripts.sh", "sha256": "ee774cb19ed6f38c8edaeaa048d008e8759d512438946f7740ff79f79a7071a3" },
     { "path": "scripts/install-vendored-ajv.sh", "sha256": "58d98426bb0dc94f73e53d535495d629df276e876534ffb2d8227557f4ccfc2c" },
     { "path": "scripts/json-canonical-check.sh", "sha256": "369c2aba329b493666c768729b0c3b4c6395ecafd012788ba44cb82202e67099" },
+    { "path": "scripts/json-canonical-fix.js", "sha256": "7c3fb6f053f122a8881acf0967e2b01fd784c2435d7cee71a8d3ebd0764fd994" },
     { "path": "scripts/policy-tools.sh", "sha256": "805620200a704dc64a6be4fa5a6261cf00d35ba747d525c405cc29b7320409ff" },
     { "path": "scripts/require-vendor-ajv.sh", "sha256": "fc58376b1e5dfb4c1cf4a22cbcf574c151e58ec90222c32144a018fc98f02389" },
     { "path": "scripts/run-ajv.sh", "sha256": "fa3e40b945144c9f8dda93f44f6c00f2e404475a3074a7bc5cf450a4e38ffe0f" },


### PR DESCRIPTION
## Summary
- add json-canonical-fix script for stable META.json ordering
- normalize META.json files and scripts manifest

## Testing
- `./scripts/hash-all.sh`
- `./scripts/json-canonical-check.sh --check`
- `./scripts/ci-run-tests.sh` *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/fast-uri)*

------
https://chatgpt.com/codex/tasks/task_e_68af2100465083319cd060b1e177e723