### PR TITLE
repo workflows; upgrade Node to v20

### DIFF
--- a/.github/workflows/registry-guard.yml
+++ b/.github/workflows/registry-guard.yml
@@ -6,7 +6,10 @@ jobs:
   guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - name: verify registry entries
         run: |
-          node -e "const fs=require('fs');const reg=JSON.parse(fs.readFileSync('registry.json'));function check(entries){return entries.every(e=>fs.existsSync(e.path));}if(!check([...(reg.standard||[]),...(reg.stage||[])])){process.exit(1);}"
+          node -e "const fs=require('fs');const reg=JSON.parse(fs.readFileSync('registry.json'));function check(entries){return entries.every(e=>fs.existsSync(e.path));}if(!check([...(reg.standard||[]),...(reg.stage||[])])){process.exit(1);}" 

--- a/.github/workflows/stage-gates.yml
+++ b/.github/workflows/stage-gates.yml
@@ -6,5 +6,8 @@ jobs:
   gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - run: scripts/validate-offline.sh

--- a/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
+++ b/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "c9962e30eec86b5273be09f6470a585f0fb67c6077f581f31b2711935a9da9b6"
   },
   "automation": {
-    "repo_commit": "3eddc5cd9a0c1d4de3eea090454178f9502f13fb",
-    "scripts_manifest_sha256": "cf7c678e10d1e01c042e5b911f7cc7ac8af6d817ebb9618bd8fa53cebdf424ab"
+    "repo_commit": "eba021364a1bedd788e548bbb956eda510c70610",
+    "scripts_manifest_sha256": "685b08716a5891aed4bfe703da356c5e9814b71f94881bcb577b9e76c0807d49"
   },
   "references": {
     "tools": [

--- a/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "3eddc5cd9a0c1d4de3eea090454178f9502f13fb",
-    "scripts_manifest_sha256": "cf7c678e10d1e01c042e5b911f7cc7ac8af6d817ebb9618bd8fa53cebdf424ab"
+    "repo_commit": "eba021364a1bedd788e548bbb956eda510c70610",
+    "scripts_manifest_sha256": "685b08716a5891aed4bfe703da356c5e9814b71f94881bcb577b9e76c0807d49"
   },
   "dependencies": [
     {

--- a/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "c9962e30eec86b5273be09f6470a585f0fb67c6077f581f31b2711935a9da9b6"
   },
   "automation": {
-    "repo_commit": "3eddc5cd9a0c1d4de3eea090454178f9502f13fb",
-    "scripts_manifest_sha256": "cf7c678e10d1e01c042e5b911f7cc7ac8af6d817ebb9618bd8fa53cebdf424ab"
+    "repo_commit": "eba021364a1bedd788e548bbb956eda510c70610",
+    "scripts_manifest_sha256": "685b08716a5891aed4bfe703da356c5e9814b71f94881bcb577b9e76c0807d49"
   },
   "references": {
     "tools": [

--- a/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "c9962e30eec86b5273be09f6470a585f0fb67c6077f581f31b2711935a9da9b6"
   },
   "automation": {
-    "repo_commit": "3eddc5cd9a0c1d4de3eea090454178f9502f13fb",
-    "scripts_manifest_sha256": "cf7c678e10d1e01c042e5b911f7cc7ac8af6d817ebb9618bd8fa53cebdf424ab"
+    "repo_commit": "eba021364a1bedd788e548bbb956eda510c70610",
+    "scripts_manifest_sha256": "685b08716a5891aed4bfe703da356c5e9814b71f94881bcb577b9e76c0807d49"
   },
   "references": {
     "tools": [

--- a/scripts_manifest.json
+++ b/scripts_manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2025-08-27T15:16:29Z",
-  "git_commit": "3eddc5cd9a0c1d4de3eea090454178f9502f13fb",
+  "generated_at": "2025-08-27T20:16:39Z",
+  "git_commit": "eba021364a1bedd788e548bbb956eda510c70610",
   "files": [
     { "path": "core/hashing/sha256.js", "sha256": "b4f9db6546461662be8652ea40f0619f2d10ee14987fb8e46b58b5c25d216738" },
     { "path": "scripts/check-registry.sh", "sha256": "d66f360cfc7350e5056a81825c2a6aeb3edea448487d2c89829799d64ea2f968" },


### PR DESCRIPTION
## Summary
- standardize registry-guard and stage-gates workflows on Node 20
- canonicalize selected META.json files and refresh scripts manifest

## Testing
- `./scripts/hash-all.sh`
- `./scripts/json-canonical-check.sh --fix`
- `./scripts/ci-run-tests.sh` *(fails: 403 Forbidden - GET https://registry.npmjs.org/fast-uri)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ajv-formats)*

------
https://chatgpt.com/codex/tasks/task_e_68af67568c188331b8162de49d08056a