### PR TITLE
global docs; update sign-off email

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 * Include:
 
 ```
-Signed-off-by: Fred Egbuedike <fredilly@yahoo.com>
+Signed-off-by: Fred Egbuedike <fredilly@article6.org>
 ```
 
 **OUTPUT FORMAT**

--- a/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
+++ b/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "c9962e30eec86b5273be09f6470a585f0fb67c6077f581f31b2711935a9da9b6"
   },
   "automation": {
-    "repo_commit": "eba021364a1bedd788e548bbb956eda510c70610",
-    "scripts_manifest_sha256": "685b08716a5891aed4bfe703da356c5e9814b71f94881bcb577b9e76c0807d49"
+    "repo_commit": "86696ff3bd8a0191364c03a04836335a519da089",
+    "scripts_manifest_sha256": "3f0b6a30cb195785320e9884445e0f6812681002387d3e9bfb4294fc3739c883"
   },
   "references": {
     "tools": [

--- a/methodologies/TEMPLATE_METHOD/META.json
+++ b/methodologies/TEMPLATE_METHOD/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "c9962e30eec86b5273be09f6470a585f0fb67c6077f581f31b2711935a9da9b6"
   },
   "automation": {
-    "repo_commit": "3eddc5cd9a0c1d4de3eea090454178f9502f13fb",
-    "scripts_manifest_sha256": "cf7c678e10d1e01c042e5b911f7cc7ac8af6d817ebb9618bd8fa53cebdf424ab"
+    "repo_commit": "86696ff3bd8a0191364c03a04836335a519da089",
+    "scripts_manifest_sha256": "3f0b6a30cb195785320e9884445e0f6812681002387d3e9bfb4294fc3739c883"
   },
   "references": {
     "tools": []

--- a/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "eba021364a1bedd788e548bbb956eda510c70610",
-    "scripts_manifest_sha256": "685b08716a5891aed4bfe703da356c5e9814b71f94881bcb577b9e76c0807d49"
+    "repo_commit": "86696ff3bd8a0191364c03a04836335a519da089",
+    "scripts_manifest_sha256": "3f0b6a30cb195785320e9884445e0f6812681002387d3e9bfb4294fc3739c883"
   },
   "dependencies": [
     {

--- a/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "c9962e30eec86b5273be09f6470a585f0fb67c6077f581f31b2711935a9da9b6"
   },
   "automation": {
-    "repo_commit": "eba021364a1bedd788e548bbb956eda510c70610",
-    "scripts_manifest_sha256": "685b08716a5891aed4bfe703da356c5e9814b71f94881bcb577b9e76c0807d49"
+    "repo_commit": "86696ff3bd8a0191364c03a04836335a519da089",
+    "scripts_manifest_sha256": "3f0b6a30cb195785320e9884445e0f6812681002387d3e9bfb4294fc3739c883"
   },
   "references": {
     "tools": [

--- a/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "c9962e30eec86b5273be09f6470a585f0fb67c6077f581f31b2711935a9da9b6"
   },
   "automation": {
-    "repo_commit": "eba021364a1bedd788e548bbb956eda510c70610",
-    "scripts_manifest_sha256": "685b08716a5891aed4bfe703da356c5e9814b71f94881bcb577b9e76c0807d49"
+    "repo_commit": "86696ff3bd8a0191364c03a04836335a519da089",
+    "scripts_manifest_sha256": "3f0b6a30cb195785320e9884445e0f6812681002387d3e9bfb4294fc3739c883"
   },
   "references": {
     "tools": [

--- a/scripts_manifest.json
+++ b/scripts_manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2025-08-27T20:16:39Z",
-  "git_commit": "eba021364a1bedd788e548bbb956eda510c70610",
+  "generated_at": "2025-08-28T06:53:28Z",
+  "git_commit": "86696ff3bd8a0191364c03a04836335a519da089",
   "files": [
     { "path": "core/hashing/sha256.js", "sha256": "b4f9db6546461662be8652ea40f0619f2d10ee14987fb8e46b58b5c25d216738" },
     { "path": "scripts/check-registry.sh", "sha256": "d66f360cfc7350e5056a81825c2a6aeb3edea448487d2c89829799d64ea2f968" },


### PR DESCRIPTION
## WHAT
- Update contributor sign-off guidance to use official article6.org address.
- Canonicalize methodology META.json files and refresh scripts manifest.

## WHY
- Maintainers confirmed the article6.org address is the correct sign-off email.
- Deterministic metadata keeps tooling reproducible.


------
https://chatgpt.com/codex/tasks/task_e_68affc0b15c08331996358c4fd15a39e