### PR TITLE
docs(pr): add PR template and branch policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## What changed
+
+- 
+
+## Why
+
+- 
+
+## Checklist
+
+- [ ] Changes are on a new branch (not `main`/`staging`)
+- [ ] Description clearly states WHAT changed and WHY
+- [ ] JSON remains canonical (2-space, LF), no secrets
+- [ ] Offline validators used (no network/npm in CI)
+- [ ] Conventional Commit(s) with required sign-off
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,11 @@ Signed-off-by: Fred Egbuedike <fredilly@article6.org>
 
 * Always run JSON/schema/registry/hash checks.
 * Stop on failure; do not commit partial changes.
+
+**BRANCH & PR POLICY**
+
+* Always create a new branch for any change (never push directly to `main`/`staging`).
+* In PR descriptions, explicitly document:
+  * What changed
+  * Why the change is needed
+* Use the PR template prompts to ensure completeness.


### PR DESCRIPTION
- Add PR template prompting WHAT and WHY
- Update AGENTS.md to enforce branching + PR description policy

WHY: Ensure every change is proposed on a new branch with clear rationale.