### PR TITLE
ci(guard): verify META.references.tools sha256 matches disk

### DIFF
--- a/scripts/check-meta-tool-hashes.js
+++ b/scripts/check-meta-tool-hashes.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Verify that META.references.tools[*].sha256 matches actual files on disk.
+// Fails fast on any mismatch or missing file. Deterministic, offline.
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const ROOT = path.resolve(__dirname, '..');
+const MROOT = path.join(ROOT, 'methodologies');
+
+function sha256(buf) { return crypto.createHash('sha256').update(buf).digest('hex'); }
+
+function* walk(dir) {
+  const ents = fs.readdirSync(dir, { withFileTypes: true });
+  for (const e of ents) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) yield* walk(p);
+    else if (e.isFile()) yield p;
+  }
+}
+
+function collectMetaFiles() {
+  const metas = [];
+  for (const p of walk(MROOT)) if (p.endsWith('/META.json')) metas.push(p);
+  metas.sort();
+  return metas;
+}
+
+let failed = 0;
+for (const metaPath of collectMetaFiles()) {
+  let meta;
+  try { meta = JSON.parse(fs.readFileSync(metaPath, 'utf8')); }
+  catch (e) { console.error(`✖ META invalid JSON: ${metaPath} — ${e.message}`); failed = 1; continue; }
+  const tools = (((meta || {}).references || {}).tools) || [];
+  const issues = [];
+  for (const t of tools.slice().sort((a,b)=>String(a.path).localeCompare(String(b.path)))) {
+    const f = path.join(ROOT, t.path);
+    if (!fs.existsSync(f) || !fs.statSync(f).isFile()) {
+      issues.push({ kind: 'missing', path: t.path });
+      continue;
+    }
+    const actual = sha256(fs.readFileSync(f));
+    if (String(t.sha256) !== actual) {
+      issues.push({ kind: 'mismatch', path: t.path, recorded: String(t.sha256), actual });
+    }
+  }
+  if (issues.length) {
+    console.error(`✖ META tool hash failures: ${metaPath}`);
+    for (const it of issues) {
+      if (it.kind === 'missing') console.error(`  - MISSING: ${it.path}`);
+      else console.error(`  - MISMATCH: ${it.path}\n    recorded: ${it.recorded}\n    actual  : ${it.actual}`);
+    }
+    failed = 1;
+  } else {
+    console.log(`✓ META tools ok: ${metaPath}`);
+  }
+}
+
+process.exit(failed ? 1 : 0);
+

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -14,6 +14,9 @@ echo "== CI: Offline Integrity Tests =="
 # Schemas vs validators consistency
 node ./scripts/check-validators-sync.js
 
+# META.tools hash verification
+node ./scripts/check-meta-tool-hashes.js
+
 # Optional: pure offline JSON Schema validation (no npm/network)
 if [ -f scripts/validators/meta.cjs ] && [ -f scripts/validators/sections.cjs ] && [ -f scripts/validators/rules.cjs ]; then
   echo "-- validators present: running offline schema validation"

--- a/scripts_manifest.json
+++ b/scripts_manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2025-08-28T09:04:51Z",
-  "git_commit": "8377886fa4ecd115deb83cd93b6af7e901390234",
+  "generated_at": "2025-08-28T09:52:18Z",
+  "git_commit": "bb51b9d6840c4c4884dff0e6db1991963adb69da",
   "files": [
     { "path": "core/hashing/sha256.js", "sha256": "b4f9db6546461662be8652ea40f0619f2d10ee14987fb8e46b58b5c25d216738" },
     { "path": "scripts/.node/node_modules/.package-lock.json", "sha256": "16314bb5d82087952ada77365dd282c93547d84e11b57595834dc9fde89bf7f4" },
@@ -549,6 +549,7 @@
     { "path": "scripts/.node/package.json", "sha256": "ee5d955a4649c11cea40798a5f2027c8d946b7d91c68eda65eddc10a14b9a301" },
     { "path": "scripts/assert-offline.sh", "sha256": "b7f69664148270ded298a4d9fb638075a21063ad7fc8e7c8b3e2d49ed88bcffd" },
     { "path": "scripts/build-validator-bundle.js", "sha256": "307a3850efc0fa6c8acb8386a296189a4541f8a62ec263de3538426cd1e4df69" },
+    { "path": "scripts/check-meta-tool-hashes.js", "sha256": "9a6ff082a4aa102412344ed6e48ca6fef9aca710776f047ac3e2a14061137e5f" },
     { "path": "scripts/check-registry.sh", "sha256": "d66f360cfc7350e5056a81825c2a6aeb3edea448487d2c89829799d64ea2f968" },
     { "path": "scripts/check-validators-sync.js", "sha256": "8ec4d1f5fb82f431873d8d7e0c39838b24399b90b1c5c69551ea62e34389c6ab" },
     { "path": "scripts/ci-run-tests.sh", "sha256": "39d43ad0bce724be5011a3d2f407c888e8c89a1822ebbe766a6fdb8fbdfc99fb" },


### PR DESCRIPTION
- Add scripts/check-meta-tool-hashes.js to recompute tool hashes and compare with META
- Wire guard into ci-run-tests.sh to fail fast on drift
- Refresh scripts_manifest.json

WHY: Detect source-hash mismatch early and deterministically in CI.

## What changed

- 

## Why

- 

## Checklist

- [ ] Changes are on a new branch (not `main`/`staging`)
- [ ] Description clearly states WHAT changed and WHY
- [ ] JSON remains canonical (2-space, LF), no secrets
- [ ] Offline validators used (no network/npm in CI)
- [ ] Conventional Commit(s) with required sign-off

