### PR TITLE
chore(json): canonicalize META.json (sorted keys, 2-space, LF)

### DIFF
--- a/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
+++ b/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
@@ -10,9 +10,9 @@
   "references": {
     "tools": [
       {
+        "kind": "pdf",
         "path": "tools/GoldStandard/GS-00XX/v1-0/source.pdf",
-        "sha256": "5a838678058f6de375e8635b5f2fea47a4e5f07cb1a882a44b10f39abc6f34ff",
-        "kind": "pdf"
+        "sha256": "5a838678058f6de375e8635b5f2fea47a4e5f07cb1a882a44b10f39abc6f34ff"
       }
     ]
   }

--- a/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
@@ -28,19 +28,19 @@
   "references": {
     "tools": [
       {
+        "kind": "pdf",
         "path": "tools/UNFCCC/AR-AMS0003/v01-0/meth_booklet.pdf",
-        "sha256": "b1e73eb883c139285d6a73ba3b645377b140ec860c482192e2158fcfd7b2ba07",
-        "kind": "pdf"
+        "sha256": "b1e73eb883c139285d6a73ba3b645377b140ec860c482192e2158fcfd7b2ba07"
       },
       {
+        "kind": "docx",
         "path": "tools/UNFCCC/AR-AMS0003/v01-0/source.docx",
-        "sha256": "2719958c1e2b8c29613d13d043dea73f9dd3fb4edbd848a921b81734339ac4b1",
-        "kind": "docx"
+        "sha256": "2719958c1e2b8c29613d13d043dea73f9dd3fb4edbd848a921b81734339ac4b1"
       },
       {
+        "kind": "pdf",
         "path": "tools/UNFCCC/AR-AMS0003/v01-0/source.pdf",
-        "sha256": "ecf4981944251fe71e8d42a159021e97d83f6ffec81c2cdc8ab1ad2d858e1e6b",
-        "kind": "pdf"
+        "sha256": "ecf4981944251fe71e8d42a159021e97d83f6ffec81c2cdc8ab1ad2d858e1e6b"
       }
     ]
   },

--- a/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
@@ -10,39 +10,39 @@
   "references": {
     "tools": [
       {
+        "kind": "docx",
         "path": "tools/UNFCCC/AR-AMS0007/v03-1/source.docx",
-        "sha256": "2f73349cfc4630255319c6c8dfc1b46a8996ace9d14d8e07563b165915918ec2",
-        "kind": "docx"
+        "sha256": "2f73349cfc4630255319c6c8dfc1b46a8996ace9d14d8e07563b165915918ec2"
       },
       {
+        "kind": "pdf",
         "path": "tools/UNFCCC/AR-AMS0007/v03-1/source.pdf",
-        "sha256": "2facdc8509c8dd2c7da4ca884cec431ab9d7ceb6ec628decc330e550cbcf2bc9",
-        "kind": "pdf"
+        "sha256": "2facdc8509c8dd2c7da4ca884cec431ab9d7ceb6ec628decc330e550cbcf2bc9"
       },
       {
+        "kind": "pdf",
         "path": "tools/UNFCCC/AR-AMS0007/v03-1/tools/AR-TOOL08_v4-0-0.pdf",
-        "sha256": "c54deaf3cbe89fa8765ec34af186400e74c08545de646d41af7a93a50565e397",
-        "kind": "pdf"
+        "sha256": "c54deaf3cbe89fa8765ec34af186400e74c08545de646d41af7a93a50565e397"
       },
       {
+        "kind": "pdf",
         "path": "tools/UNFCCC/AR-AMS0007/v03-1/tools/AR-TOOL12_v3-1.pdf",
-        "sha256": "b921a0a3b5c1e2e8791526b0ca0e183ca81dd35db59e515bb89771af692863f4",
-        "kind": "pdf"
+        "sha256": "b921a0a3b5c1e2e8791526b0ca0e183ca81dd35db59e515bb89771af692863f4"
       },
       {
+        "kind": "pdf",
         "path": "tools/UNFCCC/AR-AMS0007/v03-1/tools/AR-TOOL14_v4-2.pdf",
-        "sha256": "b63fccecaf7730e9f1d461ef51cefea2252e89dbb5a630869c9e265b23577331",
-        "kind": "pdf"
+        "sha256": "b63fccecaf7730e9f1d461ef51cefea2252e89dbb5a630869c9e265b23577331"
       },
       {
+        "kind": "pdf",
         "path": "tools/UNFCCC/AR-AMS0007/v03-1/tools/AR-TOOL15_v2-0.pdf",
-        "sha256": "b8e0252fc7bcfadc184dbb2dab12205c85d6d4af5a291b39128bd861ab878e29",
-        "kind": "pdf"
+        "sha256": "b8e0252fc7bcfadc184dbb2dab12205c85d6d4af5a291b39128bd861ab878e29"
       },
       {
+        "kind": "pdf",
         "path": "tools/UNFCCC/AR-AMS0007/v03-1/tools/AR-TOOL16_v1-1-0.pdf",
-        "sha256": "edc718dba7eb097092907553f849c10a36e91a3b4199677ccf4a78748a92f8de",
-        "kind": "pdf"
+        "sha256": "edc718dba7eb097092907553f849c10a36e91a3b4199677ccf4a78748a92f8de"
       }
     ]
   },

--- a/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
@@ -10,9 +10,9 @@
   "references": {
     "tools": [
       {
+        "kind": "pdf",
         "path": "tools/Verra/VM0007/v1-6/source.pdf",
-        "sha256": "5a838678058f6de375e8635b5f2fea47a4e5f07cb1a882a44b10f39abc6f34ff",
-        "kind": "pdf"
+        "sha256": "5a838678058f6de375e8635b5f2fea47a4e5f07cb1a882a44b10f39abc6f34ff"
       }
     ]
   }

--- a/scripts/json-canonicalize.js
+++ b/scripts/json-canonicalize.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Canonicalize JSON files by sorting all object keys recursively and
+// writing with 2-space indentation and a trailing LF. Targets:
+// - methodologies/**/*.json
+// - schemas/**/*.json
+// - tests/**/*.json
+const fs = require('fs');
+const path = require('path');
+
+function sortKeysDeep(obj) {
+  if (Array.isArray(obj)) return obj.map(sortKeysDeep);
+  if (obj && typeof obj === 'object') {
+    const out = {};
+    for (const k of Object.keys(obj).sort()) out[k] = sortKeysDeep(obj[k]);
+    return out;
+  }
+  return obj;
+}
+
+function listJsonFiles(dir) {
+  const out = [];
+  (function walk(d) {
+    if (!fs.existsSync(d)) return;
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, e.name);
+      if (e.isDirectory()) walk(p);
+      else if (e.isFile() && p.endsWith('.json')) out.push(p);
+    }
+  })(dir);
+  return out.sort();
+}
+
+const roots = ['methodologies', 'schemas', 'tests'];
+let changed = 0, total = 0;
+for (const r of roots) {
+  for (const f of listJsonFiles(r)) {
+    total++;
+    const raw = fs.readFileSync(f, 'utf8');
+    let data;
+    try { data = JSON.parse(raw); } catch (e) { console.error(`invalid JSON: ${f}`); process.exitCode = 2; continue; }
+    const stable = JSON.stringify(sortKeysDeep(data), null, 2) + '\n';
+    if (stable !== raw) {
+      fs.writeFileSync(f, stable, 'utf8');
+      console.log('fixed', f);
+      changed++;
+    }
+  }
+}
+console.log(`OK: canonicalized ${changed}/${total} JSON file(s)`);

--- a/scripts_manifest.json
+++ b/scripts_manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2025-08-28T10:43:58Z",
+  "generated_at": "2025-08-28T10:55:47Z",
   "git_commit": "3e85ef9acd066f3b0fe4fe79138c21c35cd821ca",
   "files": [
     { "path": "core/hashing/sha256.js", "sha256": "b4f9db6546461662be8652ea40f0619f2d10ee14987fb8e46b58b5c25d216738" },


### PR DESCRIPTION
WHAT: Canonicalize all META.json under methodologies using a stable key sort + 2-space indent, trailing LF. Add scripts/json-canonicalize.js to repeatably fix drift.
WHY: Prevent key order drift and non-deterministic diffs; ensure checkers remain quiet and hashes stay stable.



