### PR TITLE
ci(derive): fail on lean JSON drift; derive from rich in CI

### DIFF
--- a/.github/workflows/schema-validate.yml
+++ b/.github/workflows/schema-validate.yml
@@ -14,6 +14,14 @@ jobs:
           node-version: '20'
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Derive lean from rich (deterministic)
+        run: |
+          node scripts/derive-lean-from-rich.js
+          if ! git diff --quiet -- methodologies/**/sections.json methodologies/**/rules.json; then
+            echo "Lean JSON drift detected. Run: node scripts/derive-lean-from-rich.js";
+            git --no-pager diff -- methodologies/**/sections.json methodologies/**/rules.json | sed -n '1,200p';
+            exit 1;
+          fi
       - name: Offline schema validation
         run: node scripts/validate-offline.js
       - name: Meta-driven source hash check

--- a/.github/workflows/stage-gates.yml
+++ b/.github/workflows/stage-gates.yml
@@ -14,6 +14,14 @@ jobs:
           node-version: '20'
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Derive lean from rich (deterministic)
+        run: |
+          node scripts/derive-lean-from-rich.js
+          if ! git diff --quiet -- methodologies/**/sections.json methodologies/**/rules.json; then
+            echo "Lean JSON drift detected. Run: node scripts/derive-lean-from-rich.js";
+            git --no-pager diff -- methodologies/**/sections.json methodologies/**/rules.json | sed -n '1,200p';
+            exit 1;
+          fi
       - run: scripts/validate-offline.sh
       - name: Meta-driven source hash check
         run: bash scripts/check-source-hash.sh

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -10,4 +10,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+      - name: Derive lean from rich (deterministic)
+        run: |
+          node scripts/derive-lean-from-rich.js
+          if ! git diff --quiet -- methodologies/**/sections.json methodologies/**/rules.json; then
+            echo "Lean JSON drift detected. Run: node scripts/derive-lean-from-rich.js";
+            git --no-pager diff -- methodologies/**/sections.json methodologies/**/rules.json | sed -n '1,200p';
+            exit 1;
+          fi
       - run: scripts/validate-offline.sh


### PR DESCRIPTION
WHAT: Add a CI step to derive lean sections/rules from rich and fail if any diff exists.
WHY: Guarantee lean artifacts are purely derived and deterministic; contributors edit only rich files.



