### PR TITLE
ci(trio,registry): enforce trio presence and registry/path/version sync

### DIFF
--- a/.github/workflows/schema-validate.yml
+++ b/.github/workflows/schema-validate.yml
@@ -26,3 +26,5 @@ jobs:
         run: node scripts/validate-offline.js
       - name: Meta-driven source hash check
         run: bash scripts/check-source-hash.sh
+      - name: Trio + registry integrity
+        run: node scripts/check-trio-and-registry.js

--- a/.github/workflows/stage-gates.yml
+++ b/.github/workflows/stage-gates.yml
@@ -25,3 +25,5 @@ jobs:
       - run: scripts/validate-offline.sh
       - name: Meta-driven source hash check
         run: bash scripts/check-source-hash.sh
+      - name: Trio + registry integrity
+        run: node scripts/check-trio-and-registry.js

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -19,3 +19,5 @@ jobs:
             exit 1;
           fi
       - run: scripts/validate-offline.sh
+      - name: Trio + registry integrity
+        run: node scripts/check-trio-and-registry.js

--- a/scripts/check-trio-and-registry.js
+++ b/scripts/check-trio-and-registry.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Verify every methodologies/**/v*/ contains META.json, sections.json, rules.json
+// and registry.json lists each version exactly once with matching path+version.
+const fs = require('fs');
+const path = require('path');
+
+function *walk(d){
+  if (!fs.existsSync(d)) return;
+  for (const e of fs.readdirSync(d,{withFileTypes:true})){
+    const p = path.join(d,e.name);
+    if (e.isDirectory()) {
+      if (/^v\d/.test(e.name)) yield p;
+      yield *walk(p);
+    }
+  }
+}
+
+let failed = 0;
+const vdirs = [...walk('methodologies')].map(p=>p.split(path.sep).join('/')).sort();
+for (const d of vdirs){
+  for (const f of ['META.json','sections.json','rules.json']){
+    const p = path.join(d, f);
+    if (!fs.existsSync(p)) { console.error(`✖ MISSING ${f} in ${d}`); failed = 1; }
+  }
+}
+if (!failed) console.log('✓ All version dirs contain META.json, sections.json, rules.json');
+
+// Registry checks
+if (!fs.existsSync('registry.json')){
+  console.error('✖ registry.json missing');
+  process.exit(2);
+}
+let reg;
+try { reg = JSON.parse(fs.readFileSync('registry.json','utf8')); }
+catch (e){ console.error('✖ registry.json invalid JSON:', e.message); process.exit(2); }
+if (!Array.isArray(reg)) { console.error('✖ registry.json is not an array'); process.exit(2); }
+
+function verFromDir(vdir){ return vdir.slice(1).replace(/-/g,'.'); }
+
+let ok = 1;
+for (const v of vdirs){
+  const base = v.substring(v.lastIndexOf('/')+1);
+  const version = verFromDir(base);
+  const matches = reg.filter(e => e.path === v && e.version === version);
+  if (matches.length !== 1){
+    if (matches.length === 0){ console.error('✖ registry missing entry for', v, 'version', version); }
+    else { console.error('✖ registry duplicate/conflict for', v, 'version', version, 'count=', matches.length); }
+    ok = 0;
+  }
+}
+for (const e of reg){
+  if (!vdirs.includes(e.path)) { console.error('✖ registry lists non-existent path', e.path); ok = 0; }
+}
+if (ok) console.log('✓ registry.json matches version dirs with correct path + version');
+
+process.exit(failed || !ok ? 1 : 0);
+

--- a/scripts_manifest.json
+++ b/scripts_manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2025-08-28T13:45:37Z",
-  "git_commit": "802a9e745ce593df317aef3daa0a325f59f71d24",
+  "generated_at": "2025-08-28T14:11:09Z",
+  "git_commit": "cf0a482b283de23350897b40cc910427191c6df4",
   "files": [
     { "path": "core/hashing/sha256.js", "sha256": "b4f9db6546461662be8652ea40f0619f2d10ee14987fb8e46b58b5c25d216738" },
     { "path": "scripts/.node/node_modules/.package-lock.json", "sha256": "16314bb5d82087952ada77365dd282c93547d84e11b57595834dc9fde89bf7f4" },
@@ -549,6 +549,7 @@
     { "path": "scripts/build-validator-bundle.js", "sha256": "307a3850efc0fa6c8acb8386a296189a4541f8a62ec263de3538426cd1e4df69" },
     { "path": "scripts/check-registry.sh", "sha256": "d66f360cfc7350e5056a81825c2a6aeb3edea448487d2c89829799d64ea2f968" },
     { "path": "scripts/check-source-hash.sh", "sha256": "8a4e30a809ca5e8ce370495f859d50fe7132a8e5554023e1f1fa95ec7457f9b4" },
+    { "path": "scripts/check-trio-and-registry.js", "sha256": "8df1ab3dd5c4a5f714c067e1f8f6c173ece5da1eb4e0f9429d928aaaff65ae92" },
     { "path": "scripts/check-validators-sync.js", "sha256": "8ec4d1f5fb82f431873d8d7e0c39838b24399b90b1c5c69551ea62e34389c6ab" },
     { "path": "scripts/ci-run-tests.sh", "sha256": "a3b0da7ebba9ab472553fbd17a18c4a193c767db07accfbaf1a9e049e9565038" },
     { "path": "scripts/compile-audit.js", "sha256": "fb07855f9fffbe6d6637a05a69d66e7e67035da9bc60949b300c1e400ee51f02" },


### PR DESCRIPTION
WHAT: Add scripts/check-trio-and-registry.js and run it in all relevant workflows to verify each v*/ dir has META/sections/rules and registry.json exactly matches folder paths+versions.
WHY: Prevent missing artifacts and registry drift; ensure reviewers only edit rich files while CI verifies derived lean and registry integrity.



