### PR TITLE
TEMPLATE_METHOD examples: normalize rich authoring files

### DIFF
--- a/docs/examples/TEMPLATE_METHOD/README.md
+++ b/docs/examples/TEMPLATE_METHOD/README.md
@@ -1,0 +1,21 @@
+# TEMPLATE_METHOD authoring
+
+- Rich is the **authoring master** (humans + Codex work here).
+- Lean (`sections.json`, `rules.json`) is **generated** by the projector; never edit by hand.
+- Canonical 13 section anchors:
+  - scope-applicability
+  - definitions
+  - project-boundary-pools
+  - baseline
+  - project
+  - leakage
+  - monitoring
+  - data-parameters (children: data-parameters-ex-ante, data-parameters-ex-post)
+  - uncertainty
+  - permanence
+  - tools
+  - equations
+  - annexes
+- Rule ID pattern: `Standard.Domain.Method.Version.R-####` (e.g., `UNFCCC.Forestry.AR-AMS0007.v03-1.R-0001`).
+- Allowed rule `type` values: `eligibility`, `parameter`, `equation`, `calc`, `monitoring`, `leakage`, `uncertainty`.
+- Minimal expectations: atomic `when`, explicit units in inputs for equations, provenance in `refs`.

--- a/docs/examples/TEMPLATE_METHOD/rules.rich.json
+++ b/docs/examples/TEMPLATE_METHOD/rules.rich.json
@@ -1,2 +1,241 @@
-[]
-
+{
+  "rules": [
+    {
+      "id": "STD.Domain.Method.vX-Y.R-0001",
+      "type": "eligibility",
+      "when": [
+        "Project within scope",
+        "Land class matches national definition"
+      ],
+      "inputs": [],
+      "logic": "ELIGIBLE if all predicates true; otherwise INELIGIBLE.",
+      "notes": "Split compound predicates into atomic rules in real methods.",
+      "refs": [
+        {
+          "doc": "STD/Method@vX-Y",
+          "pages": [
+            1,
+            3
+          ]
+        }
+      ]
+    },
+    {
+      "id": "STD.Domain.Method.vX-Y.R-0010",
+      "type": "parameter",
+      "when": [
+        "Carbon fraction for aboveground biomass required"
+      ],
+      "inputs": [],
+      "logic": "Default CF = 0.47 t C per t d.m. (overridable per national default).",
+      "notes": "Mark provenance in refs.",
+      "refs": [
+        {
+          "doc": "STD/Tool@vA.B",
+          "pages": [
+            4,
+            6
+          ]
+        }
+      ]
+    },
+    {
+      "id": "STD.Domain.Method.vX-Y.R-0020",
+      "type": "parameter",
+      "when": [
+        "Root:shoot ratio required"
+      ],
+      "inputs": [],
+      "logic": "RSR_trees = 0.25; RSR_shrubs = 0.40 (dimensionless).",
+      "notes": "Override with accepted national defaults only.",
+      "refs": [
+        {
+          "doc": "STD/Tool@vA.B",
+          "pages": [
+            6
+          ]
+        }
+      ]
+    },
+    {
+      "id": "STD.Domain.Method.vX-Y.R-0100",
+      "type": "equation",
+      "when": [
+        "Compute AGB carbon at time t"
+      ],
+      "inputs": [
+        {
+          "name": "AGB_dm",
+          "unit": "t d.m. ha-1",
+          "source": "sampling"
+        },
+        {
+          "name": "CF",
+          "unit": "t C / t d.m.",
+          "source": "tool-default",
+          "default": 0.47
+        }
+      ],
+      "logic": "C_AGB_t = AGB_dm * CF  # t C ha-1",
+      "notes": "Keep output units explicit.",
+      "refs": [
+        {
+          "doc": "STD/Method@vX-Y",
+          "pages": [
+            2,
+            5
+          ]
+        }
+      ]
+    },
+    {
+      "id": "STD.Domain.Method.vX-Y.R-0110",
+      "type": "equation",
+      "when": [
+        "Convert carbon to CO2e"
+      ],
+      "inputs": [
+        {
+          "name": "C_pool",
+          "unit": "t C ha-1",
+          "source": "calc"
+        }
+      ],
+      "logic": "CO2e_pool = C_pool * 44/12  # t CO2e ha-1",
+      "notes": "Stoichiometric conversion.",
+      "refs": [
+        {
+          "doc": "STD/Method@vX-Y",
+          "pages": [
+            2,
+            5
+          ]
+        }
+      ]
+    },
+    {
+      "id": "STD.Domain.Method.vX-Y.R-0200",
+      "type": "calc",
+      "when": [
+        "Annual net GHG removals (project)"
+      ],
+      "inputs": [
+        {
+          "name": "ΔCO2e_AGB",
+          "unit": "t CO2e ha-1 yr-1",
+          "source": "calc"
+        },
+        {
+          "name": "ΔCO2e_BGB",
+          "unit": "t CO2e ha-1 yr-1",
+          "source": "calc"
+        },
+        {
+          "name": "ΔCO2e_DOM",
+          "unit": "t CO2e ha-1 yr-1",
+          "source": "calc"
+        },
+        {
+          "name": "ΔCO2e_Litter",
+          "unit": "t CO2e ha-1 yr-1",
+          "source": "calc"
+        },
+        {
+          "name": "ΔCO2e_SOC",
+          "unit": "t CO2e ha-1 yr-1",
+          "source": "calc"
+        },
+        {
+          "name": "Leakage",
+          "unit": "t CO2e ha-1 yr-1",
+          "source": "calc"
+        }
+      ],
+      "logic": "Net_project = (ΔCO2e_AGB + ΔCO2e_BGB + ΔCO2e_DOM + ΔCO2e_Litter + ΔCO2e_SOC) - Leakage",
+      "notes": "Zero excluded pools via separate eligibility rules.",
+      "refs": [
+        {
+          "doc": "STD/Method@vX-Y",
+          "pages": [
+            6,
+            9
+          ]
+        }
+      ]
+    },
+    {
+      "id": "STD.Domain.Method.vX-Y.R-0300",
+      "type": "eligibility",
+      "when": [
+        "Pool excluded by boundary selection"
+      ],
+      "inputs": [],
+      "logic": "If a pool is not in boundary, its ΔCO2e := 0.",
+      "notes": "Tie to section: project-boundary-pools.",
+      "refs": [
+        {
+          "doc": "STD/Method@vX-Y",
+          "pages": [
+            3,
+            3
+          ]
+        }
+      ]
+    },
+    {
+      "id": "STD.Domain.Method.vX-Y.R-0400",
+      "type": "uncertainty",
+      "when": [
+        "Precision check for sampling strata"
+      ],
+      "inputs": [
+        {
+          "name": "RelativePrecision",
+          "unit": "%",
+          "source": "calc"
+        }
+      ],
+      "logic": "If RelativePrecision > 10 then apply uncertainty discount per table U().",
+      "notes": "Discount table encoded as parameter rules.",
+      "refs": [
+        {
+          "doc": "STD/Method@vX-Y",
+          "pages": [
+            10,
+            12
+          ]
+        }
+      ]
+    },
+    {
+      "id": "STD.Domain.Method.vX-Y.R-0500",
+      "type": "monitoring",
+      "when": [
+        "Permanent sample plots established per design"
+      ],
+      "inputs": [
+        {
+          "name": "PlotCount",
+          "unit": "count",
+          "source": "design"
+        },
+        {
+          "name": "RevisitInterval",
+          "unit": "yr",
+          "source": "design"
+        }
+      ],
+      "logic": "Revisit plots every RevisitInterval years with consistent mensuration protocol.",
+      "notes": "Design variables explicit for QA/QC automation.",
+      "refs": [
+        {
+          "doc": "STD/Method@vX-Y",
+          "pages": [
+            13,
+            15
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/examples/TEMPLATE_METHOD/sections.rich.json
+++ b/docs/examples/TEMPLATE_METHOD/sections.rich.json
@@ -1,2 +1,110 @@
-[]
-
+{
+  "sections": [
+    {
+      "n": "1",
+      "title": "Scope and applicability",
+      "id": "scope-applicability",
+      "src": [],
+      "children": []
+    },
+    {
+      "n": "2",
+      "title": "Definitions",
+      "id": "definitions",
+      "src": [],
+      "children": []
+    },
+    {
+      "n": "3",
+      "title": "Project boundary and carbon pools",
+      "id": "project-boundary-pools",
+      "src": [],
+      "children": []
+    },
+    {
+      "n": "4",
+      "title": "Baseline scenario and net GHG emissions",
+      "id": "baseline",
+      "src": [],
+      "children": []
+    },
+    {
+      "n": "5",
+      "title": "Project scenario and net GHG removals",
+      "id": "project",
+      "src": [],
+      "children": []
+    },
+    {
+      "n": "6",
+      "title": "Leakage",
+      "id": "leakage",
+      "src": [],
+      "children": []
+    },
+    {
+      "n": "7",
+      "title": "Monitoring plan",
+      "id": "monitoring",
+      "src": [],
+      "children": []
+    },
+    {
+      "n": "8",
+      "title": "Data and parameters",
+      "id": "data-parameters",
+      "src": [],
+      "children": [
+        {
+          "n": "8.1",
+          "title": "Ex ante data/parameters",
+          "id": "data-parameters-ex-ante",
+          "src": [],
+          "children": []
+        },
+        {
+          "n": "8.2",
+          "title": "Ex post data/parameters",
+          "id": "data-parameters-ex-post",
+          "src": [],
+          "children": []
+        }
+      ]
+    },
+    {
+      "n": "9",
+      "title": "Uncertainty, precision, QA/QC",
+      "id": "uncertainty",
+      "src": [],
+      "children": []
+    },
+    {
+      "n": "10",
+      "title": "Permanence (tCERs/lCERs)",
+      "id": "permanence",
+      "src": [],
+      "children": []
+    },
+    {
+      "n": "11",
+      "title": "Normative tools and references",
+      "id": "tools",
+      "src": [],
+      "children": []
+    },
+    {
+      "n": "12",
+      "title": "Calculation procedures and equations",
+      "id": "equations",
+      "src": [],
+      "children": []
+    },
+    {
+      "n": "13",
+      "title": "Annexes",
+      "id": "annexes",
+      "src": [],
+      "children": []
+    }
+  ]
+}


### PR DESCRIPTION
## What
- add README detailing rich→lean contract and canonical anchors
- replace sections.rich.json with 13-section template
- replace rules.rich.json with registry-neutral rule stubs

## Why
- document authoring workflow and provide clean scaffold for generator


------
https://chatgpt.com/codex/tasks/task_e_68b0a44fc994833195e782fdf0175f42