### PR TITLE
chore(generator): add one-shot lean generation verifier

### DIFF
--- a/.github/workflows/schema-validate.yml
+++ b/.github/workflows/schema-validate.yml
@@ -21,6 +21,8 @@ jobs:
             git --no-pager diff -- methodologies/**/sections.json methodologies/**/rules.json | sed -n '1,200p';
             exit 1;
           fi
+      - name: Lean generation verifier
+        run: scripts/verify-generation.sh
       - name: Offline schema validation
         run: node scripts/validate-offline.js
       - name: Meta-driven source hash check

--- a/.github/workflows/stage-gates.yml
+++ b/.github/workflows/stage-gates.yml
@@ -21,6 +21,8 @@ jobs:
             git --no-pager diff -- methodologies/**/sections.json methodologies/**/rules.json | sed -n '1,200p';
             exit 1;
           fi
+      - name: Lean generation verifier
+        run: scripts/verify-generation.sh
       - name: Offline schema validation
         run: node scripts/validate-offline.js
       - name: Meta-driven source hash check

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -20,6 +20,8 @@ jobs:
             git --no-pager diff -- methodologies/**/sections.json methodologies/**/rules.json | sed -n '1,200p';
             exit 1;
           fi
+      - name: Lean generation verifier
+        run: scripts/verify-generation.sh
       - name: Offline schema validation
         run: node scripts/validate-offline.js
       - name: Meta-driven source hash check

--- a/scripts/verify-generation.sh
+++ b/scripts/verify-generation.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-shot verifier for lean generation drift
+# - Runs deterministic rich→lean derivation
+# - Fails if any methodologies/**/{sections.json,rules.json} would change
+
+node scripts/derive-lean-from-rich.js >/dev/null
+if ! git diff --quiet -- methodologies/**/sections.json methodologies/**/rules.json; then
+  echo "✖ Lean generation drift detected. Run: node scripts/derive-lean-from-rich.js" >&2
+  git --no-pager diff -- methodologies/**/sections.json methodologies/**/rules.json | sed -n '1,200p'
+  exit 1
+fi
+echo "✓ Lean generation clean (no writes needed)"
+


### PR DESCRIPTION
WHAT: scripts/verify-generation.sh runs rich→lean derivation and fails if any lean JSON would change.
WHY: Quick, idempotent check locally or in CI to confirm lean artifacts are in sync with rich.

## What

- Concise scope of change (what was added/removed/modified)
- Key files/paths touched (group by area: scripts, schemas, methodologies, tools, CI)
- Behavior changes (user‑facing, CI/guards, validation steps)
- Data model/schema changes (if any) and migrations/one‑offs
- Verification performed (commands run, checks passed) and reproducible steps

## Why

- Problem being solved and motivation
- Determinism/integrity impact (hashes, schema, CI guarantees)
- Alternatives considered and why rejected
- Risks/backwards‑compatibility and mitigations
- Related issues/links (optional)
