### PR TITLE
GS-00XX and VM0007: stub methodology JSON

### DIFF
--- a/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
+++ b/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
@@ -1,19 +1,20 @@
 {
-  "audit_hashes": {
-    "rules_json_sha256": "d3051be3d6595bb578565e5621ed4485503abcfa00d212eca4e191c9ae13e7da",
-    "sections_json_sha256": "e8a51140c778bf5afe912b3a553e0653674a76ade8cf1570f890ad84643920f7"
-  },
-  "automation": {
-    "repo_commit": "d7324060f7b6afc49a638cd0cbaaa003fce8974d",
-    "scripts_manifest_sha256": "5b7d870cd54fdc9bfaf590093daa19fed442aa4aa13220b7d112a6d35df93b66"
-  },
+  "domain": "Stub",
+  "files": [
+    {
+      "path": "sections.json",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "path": "rules.json",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  ],
+  "method": "Stub",
   "references": {
-    "tools": [
-      {
-        "path": "tools/GoldStandard/GS-00XX/v1-0/source.pdf",
-        "sha256": "5a838678058f6de375e8635b5f2fea47a4e5f07cb1a882a44b10f39abc6f34ff",
-        "kind": "pdf"
-      }
-    ]
-  }
+    "tools": []
+  },
+  "standard": "Stub",
+  "title": "Stub methodology",
+  "version": "v0-0"
 }

--- a/methodologies/GoldStandard/LUF/GS-00XX/v1-0/rules.json
+++ b/methodologies/GoldStandard/LUF/GS-00XX/v1-0/rules.json
@@ -3,10 +3,8 @@
     {
       "id": "R-1-0001",
       "section_id": "S-1",
-      "tags": [
-        "example"
-      ],
-      "text": "Example rule"
+      "tags": [],
+      "text": "Stub rule"
     }
   ]
 }

--- a/methodologies/GoldStandard/LUF/GS-00XX/v1-0/sections.json
+++ b/methodologies/GoldStandard/LUF/GS-00XX/v1-0/sections.json
@@ -2,7 +2,7 @@
   "sections": [
     {
       "id": "S-1",
-      "title": "Scope"
+      "title": "Stub section"
     }
   ]
 }

--- a/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
@@ -1,19 +1,20 @@
 {
-  "audit_hashes": {
-    "rules_json_sha256": "d3051be3d6595bb578565e5621ed4485503abcfa00d212eca4e191c9ae13e7da",
-    "sections_json_sha256": "e8a51140c778bf5afe912b3a553e0653674a76ade8cf1570f890ad84643920f7"
-  },
-  "automation": {
-    "repo_commit": "d7324060f7b6afc49a638cd0cbaaa003fce8974d",
-    "scripts_manifest_sha256": "5b7d870cd54fdc9bfaf590093daa19fed442aa4aa13220b7d112a6d35df93b66"
-  },
+  "domain": "Stub",
+  "files": [
+    {
+      "path": "sections.json",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "path": "rules.json",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  ],
+  "method": "Stub",
   "references": {
-    "tools": [
-      {
-        "path": "tools/Verra/VM0007/v1-6/source.pdf",
-        "sha256": "5a838678058f6de375e8635b5f2fea47a4e5f07cb1a882a44b10f39abc6f34ff",
-        "kind": "pdf"
-      }
-    ]
-  }
+    "tools": []
+  },
+  "standard": "Stub",
+  "title": "Stub methodology",
+  "version": "v0-0"
 }

--- a/methodologies/Verra/AFOLU/VM0007/v1-6/rules.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-6/rules.json
@@ -3,10 +3,8 @@
     {
       "id": "R-1-0001",
       "section_id": "S-1",
-      "tags": [
-        "example"
-      ],
-      "text": "Example rule"
+      "tags": [],
+      "text": "Stub rule"
     }
   ]
 }

--- a/methodologies/Verra/AFOLU/VM0007/v1-6/sections.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-6/sections.json
@@ -2,7 +2,7 @@
   "sections": [
     {
       "id": "S-1",
-      "title": "Scope"
+      "title": "Stub section"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- replace GoldStandard GS-00XX v1-0 JSON with minimal placeholders
- replace Verra VM0007 v1-6 JSON with minimal placeholders

## Testing
- `./scripts/json-canonical-check.sh --fix`
- `./scripts/hash-all.sh`
- `./scripts/ci-run-tests.sh` *(fails: Non-canonical JSON detected in unrelated files)*
- `node scripts/validate-offline.js` *(fails: META missing required property 'audit_hashes')*


------
https://chatgpt.com/codex/tasks/task_e_68b2c4f182ac833189ff37fd1e445158