### PR TITLE
feat: add http engine adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ See RULESET.md for conventions and CI guardrails.
   - Usage: `npm run cli:query -- "<query text>" --k 5`
   - Prints top‑K rules with sections, summary, and refs (tool kind/path/sha256 lifted from META).
 
+- HTTP engine adapter:
+  - Installable bin: `http-engine-adapter`
+  - Start locally: `npm run server:http -- --port 3030`
+  - POST `http://<host>:<port>/query` with `{ "query": "forest leakage" }` (optional `top_k` ≤ 50).
+  - Replies deterministically with BM25-ranked rules across AR-AMS0003 and AR-AMS0007 plus audit hashes (rules/sections/tool refs).
+
 Determinism
 - Fixed BM25 params and TF‑IDF/Linear hyperparameters; stable ordering and splits.
 - Dataset files recorded in `datasets_manifest.json` with SHA‑256.

--- a/bin/http-engine-adapter.js
+++ b/bin/http-engine-adapter.js
@@ -1,0 +1,344 @@
+#!/usr/bin/env node
+'use strict';
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const ROOT = path.resolve(__dirname, '..');
+const DEFAULT_PORT = 3030;
+const DEFAULT_HOST = '127.0.0.1';
+const MAX_BODY_BYTES = 1 * 1024 * 1024; // 1 MiB
+const BM25_PARAMS = { k1: 1.2, b: 0.75 };
+
+const METHOD_CONFIGS = [
+  { methodology_id: 'AR-AMS0003', version: 'v01-0', relDir: 'methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0' },
+  { methodology_id: 'AR-AMS0007', version: 'v03-1', relDir: 'methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1' }
+];
+
+function sha256(buf) {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+function readJSON(absPath) {
+  const raw = fs.readFileSync(absPath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function toPosixRelative(absPath) {
+  return path.relative(ROOT, absPath).split(path.sep).join('/');
+}
+
+function tokenize(text) {
+  return String(text).toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+function buildCorpus() {
+  const documents = [];
+  const perMethodAudit = [];
+  for (const cfg of METHOD_CONFIGS) {
+    const methodRoot = path.join(ROOT, cfg.relDir);
+    const metaPath = path.join(methodRoot, 'META.json');
+    const leanSectionsPath = path.join(methodRoot, 'sections.json');
+    const leanRulesPath = path.join(methodRoot, 'rules.json');
+
+    const meta = readJSON(metaPath);
+    const sectionsRaw = fs.readFileSync(leanSectionsPath);
+    const rulesRaw = fs.readFileSync(leanRulesPath);
+
+    const sectionsHash = sha256(sectionsRaw);
+    const rulesHash = sha256(rulesRaw);
+
+    const expectedSectionsHash = (((meta || {}).audit_hashes || {}).sections_json_sha256) || null;
+    const expectedRulesHash = (((meta || {}).audit_hashes || {}).rules_json_sha256) || null;
+
+    if (expectedSectionsHash && expectedSectionsHash !== sectionsHash) {
+      throw new Error(`${cfg.methodology_id} sections.json hash mismatch: expected ${expectedSectionsHash}, got ${sectionsHash}`);
+    }
+    if (expectedRulesHash && expectedRulesHash !== rulesHash) {
+      throw new Error(`${cfg.methodology_id} rules.json hash mismatch: expected ${expectedRulesHash}, got ${rulesHash}`);
+    }
+
+    const sectionsLean = readJSON(leanSectionsPath);
+    const rulesLean = readJSON(leanRulesPath);
+
+    const sectionById = new Map();
+    const sectionArr = Array.isArray(sectionsLean.sections) ? sectionsLean.sections : [];
+    for (const section of sectionArr) {
+      if (section && section.id) {
+        sectionById.set(String(section.id), {
+          id: String(section.id),
+          title: section.title ? String(section.title) : ''
+        });
+      }
+    }
+
+    const ruleArr = Array.isArray(rulesLean.rules) ? rulesLean.rules : [];
+    for (const rule of ruleArr) {
+      const ruleId = String(rule.id || '');
+      const sectionId = String(rule.section_id || '');
+      const section = sectionById.get(sectionId) || { id: sectionId, title: '' };
+      const ruleText = String(rule.text || '');
+      const compositeText = section.title ? `${section.title} - ${ruleText}` : ruleText;
+      const tokens = tokenize(compositeText);
+      const docKey = `${cfg.methodology_id}@${cfg.version}:${ruleId}`;
+      documents.push({
+        key: docKey,
+        methodology_id: cfg.methodology_id,
+        version: cfg.version,
+        rule_id: ruleId,
+        section_id: sectionId,
+        section_title: section.title,
+        text: ruleText,
+        tokens,
+        tags: Array.isArray(rule.tags) ? rule.tags.map(String) : []
+      });
+    }
+
+    const references = (((meta || {}).references || {}).tools) || [];
+    const toolRefs = references.map((ref) => ({
+      doc: ref && ref.doc ? String(ref.doc) : null,
+      kind: ref && ref.kind ? String(ref.kind) : null,
+      path: ref && ref.path ? String(ref.path) : null,
+      sha256: ref && ref.sha256 ? String(ref.sha256) : null
+    })).filter((r) => r.doc && r.path && r.sha256);
+
+    perMethodAudit.push({
+      methodology_id: cfg.methodology_id,
+      version: cfg.version,
+      rules: {
+        path: toPosixRelative(leanRulesPath),
+        sha256: rulesHash
+      },
+      sections: {
+        path: toPosixRelative(leanSectionsPath),
+        sha256: sectionsHash
+      },
+      tool_references: toolRefs
+    });
+  }
+
+  documents.sort((a, b) => a.key.localeCompare(b.key));
+
+  return {
+    documents,
+    audit: {
+      bm25: {
+        tokenizer: 'lowercase-ascii-nonalnum-split',
+        params: BM25_PARAMS,
+        documents: documents.length
+      },
+      inputs: perMethodAudit
+    }
+  };
+}
+
+function buildBM25(documents) {
+  const N = documents.length;
+  const df = new Map();
+  const docLen = new Map();
+  const tf = new Map();
+  const postings = new Map();
+  const docIndex = new Map();
+  let totalLen = 0;
+
+  for (const doc of documents) {
+    docIndex.set(doc.key, doc);
+    const tokens = doc.tokens;
+    const len = tokens.length;
+    docLen.set(doc.key, len);
+    totalLen += len;
+    const termFreq = new Map();
+    for (const t of tokens) {
+      termFreq.set(t, (termFreq.get(t) || 0) + 1);
+    }
+    tf.set(doc.key, termFreq);
+    for (const [term, freq] of termFreq.entries()) {
+      df.set(term, (df.get(term) || 0) + 1);
+      if (!postings.has(term)) postings.set(term, new Map());
+      postings.get(term).set(doc.key, freq);
+    }
+  }
+
+  const avgdl = N ? totalLen / N : 0;
+
+  function score(query) {
+    const queryTokens = Array.from(new Set(tokenize(query)));
+    if (!queryTokens.length || !N) return [];
+    const scores = new Map();
+    for (const term of queryTokens) {
+      const posting = postings.get(term);
+      if (!posting) continue;
+      const n = df.get(term) || 0;
+      if (!n) continue;
+      const idf = Math.log(1 + (N - n + 0.5) / (n + 0.5));
+      for (const [docKey, freq] of posting.entries()) {
+        const length = docLen.get(docKey) || 0;
+        const denom = freq + BM25_PARAMS.k1 * (1 - BM25_PARAMS.b + BM25_PARAMS.b * (length / (avgdl || 1)));
+        const partial = idf * (freq * (BM25_PARAMS.k1 + 1)) / (denom || 1);
+        scores.set(docKey, (scores.get(docKey) || 0) + partial);
+      }
+    }
+
+    const ranked = Array.from(scores.entries()).map(([docKey, value]) => ({
+      doc: docIndex.get(docKey),
+      score: value
+    }));
+
+    ranked.sort((a, b) => b.score - a.score || a.doc.key.localeCompare(b.doc.key));
+    return ranked;
+  }
+
+  return { score };
+}
+
+function createEngine() {
+  const { documents, audit } = buildCorpus();
+  const bm25 = buildBM25(documents);
+
+  function search(query, opts = {}) {
+    const limit = Number.isInteger(opts.topK) && opts.topK > 0 ? Math.min(opts.topK, 50) : 5;
+    if (typeof query !== 'string' || !query.trim()) {
+      return { results: [], audit, topK: limit };
+    }
+    const ranked = bm25.score(query).slice(0, limit);
+    const results = ranked.map((entry) => ({
+      doc_id: entry.doc.key,
+      methodology_id: entry.doc.methodology_id,
+      version: entry.doc.version,
+      rule_id: entry.doc.rule_id,
+      section_id: entry.doc.section_id,
+      section_title: entry.doc.section_title,
+      score: Number(entry.score.toFixed(6)),
+      text: entry.doc.text,
+      tags: entry.doc.tags
+    }));
+    return { results, audit, topK: limit };
+  }
+
+  return { search, audit };
+}
+
+async function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    const chunks = [];
+    req.on('data', (chunk) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        reject(new Error('PayloadTooLarge'));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      resolve(Buffer.concat(chunks).toString('utf8'));
+    });
+    req.on('error', reject);
+  });
+}
+
+function sendJSON(res, statusCode, payload) {
+  const body = JSON.stringify(payload);
+  res.statusCode = statusCode;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.setHeader('Content-Length', Buffer.byteLength(body));
+  res.end(body);
+}
+
+async function handleQuery(engine, req, res) {
+  try {
+    const rawBody = await readRequestBody(req);
+    let parsed;
+    try {
+      parsed = rawBody ? JSON.parse(rawBody) : null;
+    } catch (err) {
+      sendJSON(res, 400, { error: 'InvalidJSON', message: 'Body must be valid JSON' });
+      return;
+    }
+    if (!parsed || typeof parsed.query !== 'string') {
+      sendJSON(res, 400, { error: 'InvalidRequest', message: 'Body must include string field "query"' });
+      return;
+    }
+    const requestedTopK = parsed.top_k;
+    const { results, audit, topK } = engine.search(parsed.query, { topK: requestedTopK });
+    sendJSON(res, 200, {
+      query: parsed.query,
+      top_k: topK,
+      results,
+      audit
+    });
+  } catch (err) {
+    if (err && err.message === 'PayloadTooLarge') {
+      sendJSON(res, 413, { error: 'PayloadTooLarge', message: 'Request body exceeds limit' });
+      return;
+    }
+    console.error('http-engine-adapter error:', err);
+    sendJSON(res, 500, { error: 'InternalError', message: 'Unexpected error' });
+  }
+}
+
+function startServer(engine, options = {}) {
+  const port = options.port || DEFAULT_PORT;
+  const host = options.host || DEFAULT_HOST;
+  const server = http.createServer((req, res) => {
+    if (req.method === 'POST' && req.url === '/query') {
+      handleQuery(engine, req, res);
+      return;
+    }
+    if (req.method === 'GET' && req.url === '/healthz') {
+      sendJSON(res, 200, { status: 'ok', documents: engine.audit.bm25.documents });
+      return;
+    }
+    sendJSON(res, 404, { error: 'NotFound' });
+  });
+  return new Promise((resolve, reject) => {
+    server.listen(port, host, () => {
+      console.log(`http-engine-adapter listening on http://${host}:${port}`);
+      resolve(server);
+    });
+    server.on('error', reject);
+  });
+}
+
+function parseArgs(argv) {
+  const opts = { port: DEFAULT_PORT, host: DEFAULT_HOST };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--port' && i + 1 < argv.length) {
+      const next = parseInt(argv[++i], 10);
+      if (!Number.isNaN(next) && next > 0) opts.port = next;
+    } else if (arg === '--host' && i + 1 < argv.length) {
+      opts.host = argv[++i];
+    }
+  }
+  if (process.env.PORT) {
+    const envPort = parseInt(process.env.PORT, 10);
+    if (!Number.isNaN(envPort) && envPort > 0) opts.port = envPort;
+  }
+  if (process.env.HOST) {
+    opts.host = process.env.HOST;
+  }
+  return opts;
+}
+
+if (require.main === module) {
+  (async () => {
+    try {
+      const engine = createEngine();
+      const opts = parseArgs(process.argv.slice(2));
+      await startServer(engine, opts);
+    } catch (err) {
+      console.error('Failed to start http-engine-adapter:', err);
+      process.exit(1);
+    }
+  })();
+}
+
+module.exports = {
+  createEngine,
+  startServer,
+  tokenize
+};

--- a/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
+++ b/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "92aded6d176cf0a1f519cb4c4a50616da2c1453b",
-    "scripts_manifest_sha256": "ee4708ac1ddd2f986b6e4d98fe40af5c101f5f72fd2f6d175183dde60a8c980f"
+    "repo_commit": "862decd3324fc472f423144d064e3538d956b895",
+    "scripts_manifest_sha256": "8fbb364d6ddc02e61f3575c440756d9e1cafa538edd57091964648c18cab3c1d"
   },
   "domain": "Stub",
   "files": [

--- a/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "80a90d64d3f6ba202560d8f50d8243140a2f982157060e43d181f8a7860f690e"
   },
   "automation": {
-    "repo_commit": "92aded6d176cf0a1f519cb4c4a50616da2c1453b",
-    "scripts_manifest_sha256": "ee4708ac1ddd2f986b6e4d98fe40af5c101f5f72fd2f6d175183dde60a8c980f"
+    "repo_commit": "862decd3324fc472f423144d064e3538d956b895",
+    "scripts_manifest_sha256": "8fbb364d6ddc02e61f3575c440756d9e1cafa538edd57091964648c18cab3c1d"
   },
   "provenance": {
     "source_pdfs": [

--- a/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.rich.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/rules.rich.json
@@ -14,6 +14,9 @@
       ],
       "tools": [
         "UNFCCC/AR-AMS0003@v01-0"
+      ],
+      "lines": [
+        "text_anchor hint=\"Scope and applicability\" quote=\"Scope\" pages=[2]"
       ]
     },
     "summary": "ELIGIBLE if all predicates true; otherwise INELIGIBLE.",
@@ -115,22 +118,15 @@
       "source_ref": "UNFCCC/AR-AMS0003@v01-0"
     },
     "refs": {
-      "locators": [
-        {
-          "hint": "C_AGB_t = AGB_dm * CF",
-          "pages": [
-            9
-          ],
-          "quote": "AGB",
-          "type": "text_anchor"
-        }
-      ],
       "sections": [
         "S-1"
       ],
       "tools": [
         "UNFCCC/AR-AMS0003@v01-0",
         "UNFCCC/AR-TOOL14@v4.2"
+      ],
+      "lines": [
+        "text_anchor hint=\"C_AGB_t = AGB_dm * CF\" quote=\"AGB\" pages=[9]"
       ]
     },
     "summary": "C_AGB_t = AGB_dm * CF",
@@ -155,21 +151,14 @@
       "source_ref": "UNFCCC/AR-AMS0003@v01-0"
     },
     "refs": {
-      "locators": [
-        {
-          "hint": "Conversion factor",
-          "pages": [
-            9
-          ],
-          "quote": "44/12",
-          "type": "text_anchor"
-        }
-      ],
       "sections": [
         "S-1"
       ],
       "tools": [
         "UNFCCC/AR-AMS0003@v01-0"
+      ],
+      "lines": [
+        "text_anchor hint=\"Conversion factor\" quote=\"44/12\" pages=[9]"
       ]
     },
     "summary": "CO2e_pool = C_pool * 44/12",
@@ -219,21 +208,16 @@
       "source_ref": "UNFCCC/AR-AMS0003@v01-0"
     },
     "refs": {
-      "locators": [
-        {
-          "hint": "Net_project = Σ pools - leakage",
-          "pages": [
-            10
-          ],
-          "quote": "Net removals",
-          "type": "text_anchor"
-        }
-      ],
       "sections": [
-        "S-1"
+        "S-1",
+        "S-5"
       ],
       "tools": [
         "UNFCCC/AR-AMS0003@v01-0"
+      ],
+      "lines": [
+        "text_anchor hint=\"Net_project = Σ pools - leakage\" quote=\"Net removals\" pages=[10]",
+        "text_anchor hint=\"Removals and equations\" quote=\"Project scenario\" pages=[8]"
       ]
     },
     "summary": "Net_project = (dCO2e_AGB + dCO2e_BGB + dCO2e_DOM + dCO2e_Litter + dCO2e_SOC) - leakage",

--- a/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/sections.rich.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/sections.rich.json
@@ -5,18 +5,6 @@
       "source_hash": "b1e73eb883c139285d6a73ba3b645377b140ec860c482192e2158fcfd7b2ba07",
       "source_ref": "UNFCCC/AR-AMS0003@v01-0"
     },
-    "refs": {
-      "locators": [
-        {
-          "hint": "Scope and applicability",
-          "pages": [
-            2
-          ],
-          "quote": "Scope",
-          "type": "text_anchor"
-        }
-      ]
-    },
     "title": "Scope and applicability"
   },
   {
@@ -48,18 +36,6 @@
     "provenance": {
       "source_hash": "b1e73eb883c139285d6a73ba3b645377b140ec860c482192e2158fcfd7b2ba07",
       "source_ref": "UNFCCC/AR-AMS0003@v01-0"
-    },
-    "refs": {
-      "locators": [
-        {
-          "hint": "Removals and equations",
-          "pages": [
-            8
-          ],
-          "quote": "Project scenario",
-          "type": "text_anchor"
-        }
-      ]
     },
     "title": "Project scenario and net GHG removals"
   },

--- a/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "80a90d64d3f6ba202560d8f50d8243140a2f982157060e43d181f8a7860f690e"
   },
   "automation": {
-    "repo_commit": "92aded6d176cf0a1f519cb4c4a50616da2c1453b",
-    "scripts_manifest_sha256": "ee4708ac1ddd2f986b6e4d98fe40af5c101f5f72fd2f6d175183dde60a8c980f"
+    "repo_commit": "862decd3324fc472f423144d064e3538d956b895",
+    "scripts_manifest_sha256": "8fbb364d6ddc02e61f3575c440756d9e1cafa538edd57091964648c18cab3c1d"
   },
   "provenance": {
     "author": "Fred Egbuedike",

--- a/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.rich.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/rules.rich.json
@@ -15,6 +15,9 @@
       "tools": [
         "UNFCCC/AR-AMS0007@v03-1",
         "UNFCCC/AR-TOOL14@v4.2"
+      ],
+      "lines": [
+        "text_anchor hint=\"Eligibility scope\" quote=\"Scope and applicability\" pages=[2]"
       ]
     },
     "summary": "ELIGIBLE if all predicates true; otherwise INELIGIBLE.",
@@ -117,22 +120,15 @@
       "source_ref": "UNFCCC/AR-AMS0007@v03-1"
     },
     "refs": {
-      "locators": [
-        {
-          "hint": "C_AGB_t = AGB_dm * CF",
-          "pages": [
-            11
-          ],
-          "quote": "AGB",
-          "type": "text_anchor"
-        }
-      ],
       "sections": [
         "S-1"
       ],
       "tools": [
         "UNFCCC/AR-AMS0007@v03-1",
         "UNFCCC/AR-TOOL14@v4.2"
+      ],
+      "lines": [
+        "text_anchor hint=\"C_AGB_t = AGB_dm * CF\" quote=\"AGB\" pages=[11]"
       ]
     },
     "summary": "C_AGB_t = AGB_dm * CF",
@@ -157,21 +153,14 @@
       "source_ref": "UNFCCC/AR-AMS0007@v03-1"
     },
     "refs": {
-      "locators": [
-        {
-          "hint": "Stoichiometric conversion",
-          "pages": [
-            11
-          ],
-          "quote": "44/12",
-          "type": "text_anchor"
-        }
-      ],
       "sections": [
         "S-1"
       ],
       "tools": [
         "UNFCCC/AR-AMS0007@v03-1"
+      ],
+      "lines": [
+        "text_anchor hint=\"Stoichiometric conversion\" quote=\"44/12\" pages=[11]"
       ]
     },
     "summary": "CO2e_pool = C_pool * 44/12",
@@ -221,21 +210,16 @@
       "source_ref": "UNFCCC/AR-AMS0007@v03-1"
     },
     "refs": {
-      "locators": [
-        {
-          "hint": "Net_project = ... - leakage",
-          "pages": [
-            12
-          ],
-          "quote": "Net removals",
-          "type": "text_anchor"
-        }
-      ],
       "sections": [
-        "S-1"
+        "S-1",
+        "S-5"
       ],
       "tools": [
         "UNFCCC/AR-AMS0007@v03-1"
+      ],
+      "lines": [
+        "text_anchor hint=\"Net_project = ... - leakage\" quote=\"Net removals\" pages=[12]",
+        "text_anchor hint=\"Removals and equations\" quote=\"Project scenario\" pages=[10]"
       ]
     },
     "summary": "Net_project = (dCO2e_AGB + dCO2e_BGB + dCO2e_DOM + dCO2e_Litter + dCO2e_SOC) - leakage",

--- a/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/sections.rich.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/sections.rich.json
@@ -5,18 +5,6 @@
       "source_hash": "2facdc8509c8dd2c7da4ca884cec431ab9d7ceb6ec628decc330e550cbcf2bc9",
       "source_ref": "UNFCCC/AR-AMS0007@v03-1"
     },
-    "refs": {
-      "locators": [
-        {
-          "hint": "Eligibility scope",
-          "pages": [
-            2
-          ],
-          "quote": "Scope and applicability",
-          "type": "text_anchor"
-        }
-      ]
-    },
     "title": "Scope and applicability"
   },
   {
@@ -48,18 +36,6 @@
     "provenance": {
       "source_hash": "2facdc8509c8dd2c7da4ca884cec431ab9d7ceb6ec628decc330e550cbcf2bc9",
       "source_ref": "UNFCCC/AR-AMS0007@v03-1"
-    },
-    "refs": {
-      "locators": [
-        {
-          "hint": "Removals and equations",
-          "pages": [
-            10
-          ],
-          "quote": "Project scenario",
-          "type": "text_anchor"
-        }
-      ]
     },
     "title": "Project scenario and net GHG removals"
   },

--- a/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "92aded6d176cf0a1f519cb4c4a50616da2c1453b",
-    "scripts_manifest_sha256": "ee4708ac1ddd2f986b6e4d98fe40af5c101f5f72fd2f6d175183dde60a8c980f"
+    "repo_commit": "862decd3324fc472f423144d064e3538d956b895",
+    "scripts_manifest_sha256": "8fbb364d6ddc02e61f3575c440756d9e1cafa538edd57091964648c18cab3c1d"
   },
   "domain": "Stub",
   "files": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "article6-methodologies",
   "private": true,
   "bin": {
-    "mrv-cli": "bin/mrv-cli.js"
+    "mrv-cli": "bin/mrv-cli.js",
+    "http-engine-adapter": "bin/http-engine-adapter.js"
   },
   "engines": {
     "node": ">=20 <21"
@@ -23,7 +24,8 @@
     "dataset:params": "node scripts/gen-dataset-params.js",
     "eval:params:tfidf": "node scripts/baselines/param-extraction-tfidf.js",
     "eval:params:linear": "node scripts/baselines/param-extraction-linear.js",
-    "cli:query": "node bin/mrv-cli.js"
+    "cli:query": "node bin/mrv-cli.js",
+    "server:http": "node bin/http-engine-adapter.js"
   },
   "dependencies": {
     "fast-deep-equal": "file:vendor/npm/fast-deep-equal-3.1.3.tgz",

--- a/scripts_manifest.json
+++ b/scripts_manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2025-09-11T16:29:58Z",
-  "git_commit": "92aded6d176cf0a1f519cb4c4a50616da2c1453b",
+  "generated_at": "2025-09-18T15:48:12Z",
+  "git_commit": "862decd3324fc472f423144d064e3538d956b895",
   "files": [
     { "path": "core/hashing/sha256.js", "sha256": "b4f9db6546461662be8652ea40f0619f2d10ee14987fb8e46b58b5c25d216738" },
     { "path": "scripts/.node/node_modules/.package-lock.json", "sha256": "16314bb5d82087952ada77365dd282c93547d84e11b57595834dc9fde89bf7f4" },
@@ -548,6 +548,7 @@
     { "path": "scripts/assert-offline.sh", "sha256": "b7f69664148270ded298a4d9fb638075a21063ad7fc8e7c8b3e2d49ed88bcffd" },
     { "path": "scripts/assert-tool-hashes.sh", "sha256": "df6b46b70aaee6bbe0e107afbb9a64c50e125d8ae22479d1d3f4722d84cc316a" },
     { "path": "scripts/baselines/bm25-retrieval.js", "sha256": "a4fecca2f1d899bcf892de00c3dd09b9cac5d7b51049fc0401b94c1710a587c9" },
+    { "path": "scripts/baselines/param-extraction-linear.js", "sha256": "13f483627ff922c5d41d5d2d60f03c53a207d30eee1ba9a3758b863b2323c2ea" },
     { "path": "scripts/baselines/param-extraction-tfidf.js", "sha256": "9ba211f2a139daf0bd1a857205c3ede17f741c71fe345d4de2148cd8b2a70c8a" },
     { "path": "scripts/build-validator-bundle.js", "sha256": "307a3850efc0fa6c8acb8386a296189a4541f8a62ec263de3538426cd1e4df69" },
     { "path": "scripts/check-lean-drift.sh", "sha256": "6c482f7b7ed321f6612c8e1a347921894613cf500fa013f0f1c3904e9b78713f" },


### PR DESCRIPTION
Add a deterministic BM25-backed HTTP query adapter that verifies methodology hashes before serving responses. Move section anchor references into rules.rich.json to keep schemas intact while preserving locator context in refs.lines.

## What

- Concise scope of change (what was added/removed/modified)
- Key files/paths touched (group by area: scripts, schemas, methodologies, tools, CI)
- Behavior changes (user‑facing, CI/guards, validation steps)
- Data model/schema changes (if any) and migrations/one‑offs
- Verification performed (commands run, checks passed) and reproducible steps

## Why

- Problem being solved and motivation
- Determinism/integrity impact (hashes, schema, CI guarantees)
- Alternatives considered and why rejected
- Risks/backwards‑compatibility and mitigations
- Related issues/links (optional)
