### PR TITLE
feat: add serverless endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ outputs/*
 vendor/ajv-cli/
 .DS_Store
 vendor/ajv-cli/
+.vercel

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ See RULESET.md for conventions and CI guardrails.
   - Start locally: `npm run server:http -- --port 3030`
   - POST `http://<host>:<port>/query` with `{ "query": "forest leakage" }` (optional `top_k` ≤ 50).
   - Replies deterministically with BM25-ranked rules across AR-AMS0003 and AR-AMS0007 plus audit hashes (rules/sections/tool refs).
+- Serverless endpoint (Vercel-style `/api/query`):
+  - GET `/api/query?text=forest+leakage[&top_k=5]` for ad-hoc checks.
+  - POST `/api/query` with `{ "query": "forest leakage", "top_k": 5 }` for structured calls.
+  - Delegates to the same deterministic BM25 engine to keep outputs aligned with the CLI/HTTP adapter.
+- Health check:
+  - GET `/api/healthz` → `{ "status": "ok", "documents": 26 }` (document count driven by corpus size).
 
 Determinism
 - Fixed BM25 params and TF‑IDF/Linear hyperparameters; stable ordering and splits.

--- a/api/healthz.js
+++ b/api/healthz.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const { createEngine } = require('../bin/http-engine-adapter');
+
+let engine;
+
+function ensureEngine() {
+  if (!engine) {
+    engine = createEngine();
+  }
+  return engine;
+}
+
+module.exports = async function handler(req, res) {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  const engineInstance = ensureEngine();
+  const count = engineInstance.audit?.bm25?.documents || 0;
+  const body = JSON.stringify({ status: 'ok', documents: count });
+  res.setHeader('Content-Length', Buffer.byteLength(body));
+  res.end(body);
+};

--- a/api/query.js
+++ b/api/query.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const { URL } = require('url');
+const { createEngine } = require('../bin/http-engine-adapter');
+
+let engine;
+
+function ensureEngine() {
+  if (!engine) {
+    engine = createEngine();
+  }
+  return engine;
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    if (req.body && typeof req.body === 'object') {
+      return resolve(req.body);
+    }
+    const chunks = [];
+    req.on('data', chunk => chunks.push(chunk));
+    req.on('end', () => {
+      if (!chunks.length) {
+        resolve(null);
+        return;
+      }
+      try {
+        const parsed = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+        resolve(parsed);
+      } catch (err) {
+        reject(Object.assign(new Error('Invalid JSON body'), { statusCode: 400 }));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function send(res, statusCode, payload) {
+  const body = JSON.stringify(payload);
+  res.statusCode = statusCode;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.setHeader('Content-Length', Buffer.byteLength(body));
+  res.end(body);
+}
+
+function parseQueryFromUrl(reqUrl) {
+  try {
+    const u = new URL(reqUrl, 'http://localhost');
+    return {
+      text: u.searchParams.get('text') || u.searchParams.get('query') || '',
+      topK: u.searchParams.get('top_k') || u.searchParams.get('topK') || null
+    };
+  } catch {
+    return { text: '', topK: null };
+  }
+}
+
+module.exports = async function handler(req, res) {
+  const method = (req.method || 'GET').toUpperCase();
+  const engineInstance = ensureEngine();
+
+  try {
+    if (method === 'GET') {
+      const { text, topK } = parseQueryFromUrl(req.url || '');
+      if (!text) {
+        send(res, 400, { error: 'InvalidRequest', message: 'Provide ?text= query string' });
+        return;
+      }
+      const { results, audit, topK: effectiveTopK } = engineInstance.search(text, { topK: topK ? Number(topK) : undefined });
+      send(res, 200, { query: text, top_k: effectiveTopK, results, audit });
+      return;
+    }
+
+    if (method === 'POST') {
+      const body = await parseBody(req);
+      if (!body || typeof body.query !== 'string') {
+        send(res, 400, { error: 'InvalidRequest', message: 'Body must include string "query"' });
+        return;
+      }
+      const topK = Number.isInteger(body.top_k) ? body.top_k : body.topK;
+      const { results, audit, topK: effectiveTopK } = engineInstance.search(body.query, { topK });
+      send(res, 200, { query: body.query, top_k: effectiveTopK, results, audit });
+      return;
+    }
+
+    if (method === 'OPTIONS') {
+      res.statusCode = 204;
+      res.setHeader('Allow', 'GET,POST,OPTIONS');
+      res.end();
+      return;
+    }
+
+    send(res, 405, { error: 'MethodNotAllowed', message: 'Use GET or POST' });
+  } catch (err) {
+    const statusCode = err && err.statusCode ? err.statusCode : 500;
+    send(res, statusCode, { error: 'ServerError', message: 'Unexpected error' });
+  }
+};

--- a/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
+++ b/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "862decd3324fc472f423144d064e3538d956b895",
-    "scripts_manifest_sha256": "8fbb364d6ddc02e61f3575c440756d9e1cafa538edd57091964648c18cab3c1d"
+    "repo_commit": "5bd11e6ce6e27e41604b7b71f4dc94269cfb1e81",
+    "scripts_manifest_sha256": "2519134509b5611e426c1bbbca639f0fb3de8fdccc1391f43a63d8c777ba61bd"
   },
   "domain": "Stub",
   "files": [

--- a/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "80a90d64d3f6ba202560d8f50d8243140a2f982157060e43d181f8a7860f690e"
   },
   "automation": {
-    "repo_commit": "862decd3324fc472f423144d064e3538d956b895",
-    "scripts_manifest_sha256": "8fbb364d6ddc02e61f3575c440756d9e1cafa538edd57091964648c18cab3c1d"
+    "repo_commit": "5bd11e6ce6e27e41604b7b71f4dc94269cfb1e81",
+    "scripts_manifest_sha256": "2519134509b5611e426c1bbbca639f0fb3de8fdccc1391f43a63d8c777ba61bd"
   },
   "provenance": {
     "source_pdfs": [

--- a/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "80a90d64d3f6ba202560d8f50d8243140a2f982157060e43d181f8a7860f690e"
   },
   "automation": {
-    "repo_commit": "862decd3324fc472f423144d064e3538d956b895",
-    "scripts_manifest_sha256": "8fbb364d6ddc02e61f3575c440756d9e1cafa538edd57091964648c18cab3c1d"
+    "repo_commit": "5bd11e6ce6e27e41604b7b71f4dc94269cfb1e81",
+    "scripts_manifest_sha256": "2519134509b5611e426c1bbbca639f0fb3de8fdccc1391f43a63d8c777ba61bd"
   },
   "provenance": {
     "author": "Fred Egbuedike",

--- a/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "862decd3324fc472f423144d064e3538d956b895",
-    "scripts_manifest_sha256": "8fbb364d6ddc02e61f3575c440756d9e1cafa538edd57091964648c18cab3c1d"
+    "repo_commit": "5bd11e6ce6e27e41604b7b71f4dc94269cfb1e81",
+    "scripts_manifest_sha256": "2519134509b5611e426c1bbbca639f0fb3de8fdccc1391f43a63d8c777ba61bd"
   },
   "domain": "Stub",
   "files": [

--- a/scripts_manifest.json
+++ b/scripts_manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2025-09-18T15:48:12Z",
-  "git_commit": "862decd3324fc472f423144d064e3538d956b895",
+  "generated_at": "2025-09-19T05:11:29Z",
+  "git_commit": "5bd11e6ce6e27e41604b7b71f4dc94269cfb1e81",
   "files": [
     { "path": "core/hashing/sha256.js", "sha256": "b4f9db6546461662be8652ea40f0619f2d10ee14987fb8e46b58b5c25d216738" },
     { "path": "scripts/.node/node_modules/.package-lock.json", "sha256": "16314bb5d82087952ada77365dd282c93547d84e11b57595834dc9fde89bf7f4" },

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "version": 2,
+  "routes": [
+    { "src": "/healthz", "dest": "api/healthz.js" },
+    { "src": "/query", "dest": "api/query.js" }
+  ]
+}


### PR DESCRIPTION
Add Vercel-compatible handlers for /api/query and /api/healthz. Update documentation and refresh automation hashes after running hash-all.

## What

- Concise scope of change (what was added/removed/modified)
- Key files/paths touched (group by area: scripts, schemas, methodologies, tools, CI)
- Behavior changes (user‑facing, CI/guards, validation steps)
- Data model/schema changes (if any) and migrations/one‑offs
- Verification performed (commands run, checks passed) and reproducible steps

## Why

- Problem being solved and motivation
- Determinism/integrity impact (hashes, schema, CI guarantees)
- Alternatives considered and why rejected
- Risks/backwards‑compatibility and mitigations
- Related issues/links (optional)
