### PR TITLE
feat(baselines): export param linear manifest

### DIFF
--- a/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
+++ b/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "6b5c514999e6beac5aeb880d5fd52230c89f7c75",
-    "scripts_manifest_sha256": "4d5a8dd440fa44f6ec57a5929f80b9a19a9392fa2bef0bb11e128c2a412af8de"
+    "repo_commit": "e63172ed32c6d117a320f97e03f157c62f9105b8",
+    "scripts_manifest_sha256": "5e60af06f34b534ea051e06539d8e394f9e910654999d085707734d2ad403f4b"
   },
   "domain": "Stub",
   "files": [

--- a/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "80a90d64d3f6ba202560d8f50d8243140a2f982157060e43d181f8a7860f690e"
   },
   "automation": {
-    "repo_commit": "6b5c514999e6beac5aeb880d5fd52230c89f7c75",
-    "scripts_manifest_sha256": "4d5a8dd440fa44f6ec57a5929f80b9a19a9392fa2bef0bb11e128c2a412af8de"
+    "repo_commit": "e63172ed32c6d117a320f97e03f157c62f9105b8",
+    "scripts_manifest_sha256": "5e60af06f34b534ea051e06539d8e394f9e910654999d085707734d2ad403f4b"
   },
   "provenance": {
     "source_pdfs": [

--- a/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "80a90d64d3f6ba202560d8f50d8243140a2f982157060e43d181f8a7860f690e"
   },
   "automation": {
-    "repo_commit": "6b5c514999e6beac5aeb880d5fd52230c89f7c75",
-    "scripts_manifest_sha256": "4d5a8dd440fa44f6ec57a5929f80b9a19a9392fa2bef0bb11e128c2a412af8de"
+    "repo_commit": "e63172ed32c6d117a320f97e03f157c62f9105b8",
+    "scripts_manifest_sha256": "5e60af06f34b534ea051e06539d8e394f9e910654999d085707734d2ad403f4b"
   },
   "provenance": {
     "author": "Fred Egbuedike",

--- a/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "6b5c514999e6beac5aeb880d5fd52230c89f7c75",
-    "scripts_manifest_sha256": "4d5a8dd440fa44f6ec57a5929f80b9a19a9392fa2bef0bb11e128c2a412af8de"
+    "repo_commit": "e63172ed32c6d117a320f97e03f157c62f9105b8",
+    "scripts_manifest_sha256": "5e60af06f34b534ea051e06539d8e394f9e910654999d085707734d2ad403f4b"
   },
   "domain": "Stub",
   "files": [

--- a/outputs/mvp/params.linear.e63172e-seed42.json
+++ b/outputs/mvp/params.linear.e63172e-seed42.json
@@ -1,0 +1,23 @@
+{
+  "tag": "params.linear",
+  "commit_sha": "e63172ed32c6d117a320f97e03f157c62f9105b8",
+  "generated_at": "2025-09-22T07:40:09+01:00",
+  "dataset": "datasets/param-extraction/v1",
+  "seed": 42,
+  "metrics": {
+    "variables": {
+      "micro_f1": 0.6364,
+      "precision": 0.4667,
+      "recall": 1
+    },
+    "units": {
+      "micro_f1": 0.9091,
+      "precision": 1,
+      "recall": 0.8333
+    }
+  },
+  "stdout": [
+    "variables microF1=0.6364 (P=0.4667 R=1.0000)",
+    "units microF1=0.9091 (P=1.0000 R=0.8333)"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dataset:params": "node scripts/gen-dataset-params.js",
     "eval:params:tfidf": "node scripts/baselines/param-extraction-tfidf.js",
     "eval:params:linear": "node scripts/baselines/param-extraction-linear.js",
+    "eval:params:linear:json": "node scripts/baselines/param-extraction-linear-json.js",
     "cli:query": "node bin/mrv-cli.js",
     "server:http": "node bin/http-engine-adapter.js"
   },

--- a/scripts/baselines/param-extraction-linear-json.js
+++ b/scripts/baselines/param-extraction-linear-json.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Wrapper for the deterministic TF-IDF/linear param extraction baseline.
+ * Runs the existing baseline script, parses stdout metrics, and writes
+ * a reproducible JSON manifest under outputs/mvp/params.linear.<tag>.json.
+ */
+const { spawnSync, execSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const seed = process.env.SEED || '42';
+
+const baseline = spawnSync(process.execPath, [path.join(__dirname, 'param-extraction-linear.js')], {
+  cwd: repoRoot,
+  env: { ...process.env, SEED: seed },
+  encoding: 'utf8'
+});
+
+if (baseline.error) {
+  throw baseline.error;
+}
+if (baseline.status !== 0) {
+  process.stderr.write(baseline.stdout || '');
+  process.stderr.write(baseline.stderr || '');
+  throw new Error(`param-extraction-linear exited with status ${baseline.status}`);
+}
+
+const lines = baseline.stdout.trim().split(/\r?\n/).filter(Boolean);
+const parseLine = (line, label) => {
+  const match = line.match(/^(variables|units) microF1=([0-9.]+) \(P=([0-9.]+) R=([0-9.]+)\)$/);
+  if (!match) {
+    throw new Error(`Unable to parse ${label} line: ${line}`);
+  }
+  return {
+    micro_f1: Number(match[2]),
+    precision: Number(match[3]),
+    recall: Number(match[4])
+  };
+};
+
+const variableLine = lines.find((l) => l.startsWith('variables '));
+const unitLine = lines.find((l) => l.startsWith('units '));
+
+if (!variableLine || !unitLine) {
+  throw new Error(`Unexpected baseline output:\n${baseline.stdout}`);
+}
+
+const metrics = {
+  variables: parseLine(variableLine, 'variables'),
+  units: parseLine(unitLine, 'units')
+};
+
+const commit = execSync('git rev-parse HEAD', { cwd: repoRoot, encoding: 'utf8' }).trim();
+const shortCommit = execSync('git rev-parse --short HEAD', { cwd: repoRoot, encoding: 'utf8' }).trim();
+const commitTimestamp = execSync('git show -s --format=%cI HEAD', { cwd: repoRoot, encoding: 'utf8' }).trim();
+const tag = `${shortCommit}-seed${seed}`;
+
+const manifest = {
+  tag: 'params.linear',
+  commit_sha: commit,
+  generated_at: commitTimestamp,
+  dataset: 'datasets/param-extraction/v1',
+  seed: Number.isNaN(Number(seed)) ? seed : Number(seed),
+  metrics,
+  stdout: lines
+};
+
+const outDir = path.join(repoRoot, 'outputs', 'mvp');
+fs.mkdirSync(outDir, { recursive: true });
+
+const outPath = path.join(outDir, `params.linear.${tag}.json`);
+fs.writeFileSync(outPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+console.log(outPath);

--- a/scripts_manifest.json
+++ b/scripts_manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2025-09-22T05:17:30Z",
-  "git_commit": "6b5c514999e6beac5aeb880d5fd52230c89f7c75",
+  "generated_at": "2025-09-22T18:48:16Z",
+  "git_commit": "e63172ed32c6d117a320f97e03f157c62f9105b8",
   "files": [
     { "path": "core/hashing/sha256.js", "sha256": "b4f9db6546461662be8652ea40f0619f2d10ee14987fb8e46b58b5c25d216738" },
     { "path": "scripts/.node/node_modules/.package-lock.json", "sha256": "16314bb5d82087952ada77365dd282c93547d84e11b57595834dc9fde89bf7f4" },
@@ -548,6 +548,7 @@
     { "path": "scripts/assert-offline.sh", "sha256": "b7f69664148270ded298a4d9fb638075a21063ad7fc8e7c8b3e2d49ed88bcffd" },
     { "path": "scripts/assert-tool-hashes.sh", "sha256": "df6b46b70aaee6bbe0e107afbb9a64c50e125d8ae22479d1d3f4722d84cc316a" },
     { "path": "scripts/baselines/bm25-retrieval.js", "sha256": "a4fecca2f1d899bcf892de00c3dd09b9cac5d7b51049fc0401b94c1710a587c9" },
+    { "path": "scripts/baselines/param-extraction-linear-json.js", "sha256": "95c48577722e227d980fd650331262b928daee2288f715379c878624c52962b2" },
     { "path": "scripts/baselines/param-extraction-linear.js", "sha256": "13f483627ff922c5d41d5d2d60f03c53a207d30eee1ba9a3758b863b2323c2ea" },
     { "path": "scripts/baselines/param-extraction-tfidf.js", "sha256": "9ba211f2a139daf0bd1a857205c3ede17f741c71fe345d4de2148cd8b2a70c8a" },
     { "path": "scripts/build-validator-bundle.js", "sha256": "307a3850efc0fa6c8acb8386a296189a4541f8a62ec263de3538426cd1e4df69" },


### PR DESCRIPTION
## WHAT
- Add wrapper script that parses param-extraction linear stdout and writes deterministic JSON manifests
- Expose `npm run eval:params:linear:json` helper for investor evidence
- Refresh automation pins and add `params.linear.e63172e-seed42` output under `outputs/mvp`

## WHY
- Preserve reproducible param baseline metrics with seed 42 for audit deck
- Keep scripts manifest and META automation aligned with new tooling

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>


