### PR TITLE
feat(engine): add health badge and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Article6 Methodologies (data-first, audit-ready)
+![Engine Health](https://img.shields.io/endpoint?url=https%3A%2F%2Fdemo.article6.org%2Fapi%2Fhealthz%3Fbadge%3D1)
 Canonical store of methodologies: META + sections + rules (+ tools, overrides, tests, core).
 For a working example of the file layout and content, see `docs/examples/TEMPLATE_METHOD`.
 See RULESET.md for conventions and CI guardrails.
@@ -44,6 +45,7 @@ See RULESET.md for conventions and CI guardrails.
   - Start locally: `npm run server:http -- --port 3030`
   - POST `http://<host>:<port>/query` with `{ "query": "forest leakage" }` (optional `top_k` ≤ 50).
   - Replies deterministically with BM25-ranked rules across AR-AMS0003 and AR-AMS0007 plus audit hashes (rules/sections/tool refs).
+  - Metrics logging: every request prints `requests=<n> p95_ms=<latency>`; set `ENGINE_METRICS_LOG=/path/to/file.log` to append to disk.
 - Serverless endpoint (Vercel-style `/api/query`):
   - GET `/api/query?text=forest+leakage[&top_k=5]` for ad-hoc checks.
   - POST `/api/query` with `{ "query": "forest leakage", "top_k": 5 }` for structured calls.

--- a/core/metrics/request-metrics.js
+++ b/core/metrics/request-metrics.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const durations = [];
+const WINDOW_SIZE = Number(process.env.ENGINE_METRICS_WINDOW || 200) || 200;
+const LOG_PATH = process.env.ENGINE_METRICS_LOG ? path.resolve(process.env.ENGINE_METRICS_LOG) : null;
+let total = 0;
+
+function percentile(values, p) {
+  if (!values.length) return 0;
+  const sorted = values.slice().sort((a, b) => a - b);
+  const rank = Math.ceil((p / 100) * sorted.length) - 1;
+  const idx = Math.min(sorted.length - 1, Math.max(0, rank));
+  return sorted[idx];
+}
+
+function recordRequest(durationMs) {
+  total += 1;
+  durations.push(durationMs);
+  if (durations.length > WINDOW_SIZE) durations.shift();
+
+  const p95 = percentile(durations, 95);
+  const line = `[engine] requests=${total} p95_ms=${p95.toFixed(2)}`;
+  console.log(line);
+
+  if (LOG_PATH) {
+    const entry = `${new Date().toISOString()} ${line}\n`;
+    fs.appendFile(LOG_PATH, entry, (err) => {
+      if (err) console.warn('[engine] metrics log append failed', err.message || err);
+    });
+  }
+}
+
+module.exports = { recordRequest };

--- a/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
+++ b/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "5bd11e6ce6e27e41604b7b71f4dc94269cfb1e81",
-    "scripts_manifest_sha256": "2519134509b5611e426c1bbbca639f0fb3de8fdccc1391f43a63d8c777ba61bd"
+    "repo_commit": "da29ec9df2426cce6e815bf8f3c93f1dc53c8297",
+    "scripts_manifest_sha256": "f0dcf1542b08e4d562a94de28e4f67ddcf2c2c1037047a2848be217094487fa8"
   },
   "domain": "Stub",
   "files": [

--- a/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "80a90d64d3f6ba202560d8f50d8243140a2f982157060e43d181f8a7860f690e"
   },
   "automation": {
-    "repo_commit": "5bd11e6ce6e27e41604b7b71f4dc94269cfb1e81",
-    "scripts_manifest_sha256": "2519134509b5611e426c1bbbca639f0fb3de8fdccc1391f43a63d8c777ba61bd"
+    "repo_commit": "da29ec9df2426cce6e815bf8f3c93f1dc53c8297",
+    "scripts_manifest_sha256": "f0dcf1542b08e4d562a94de28e4f67ddcf2c2c1037047a2848be217094487fa8"
   },
   "provenance": {
     "source_pdfs": [

--- a/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "80a90d64d3f6ba202560d8f50d8243140a2f982157060e43d181f8a7860f690e"
   },
   "automation": {
-    "repo_commit": "5bd11e6ce6e27e41604b7b71f4dc94269cfb1e81",
-    "scripts_manifest_sha256": "2519134509b5611e426c1bbbca639f0fb3de8fdccc1391f43a63d8c777ba61bd"
+    "repo_commit": "da29ec9df2426cce6e815bf8f3c93f1dc53c8297",
+    "scripts_manifest_sha256": "f0dcf1542b08e4d562a94de28e4f67ddcf2c2c1037047a2848be217094487fa8"
   },
   "provenance": {
     "author": "Fred Egbuedike",

--- a/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "5bd11e6ce6e27e41604b7b71f4dc94269cfb1e81",
-    "scripts_manifest_sha256": "2519134509b5611e426c1bbbca639f0fb3de8fdccc1391f43a63d8c777ba61bd"
+    "repo_commit": "da29ec9df2426cce6e815bf8f3c93f1dc53c8297",
+    "scripts_manifest_sha256": "f0dcf1542b08e4d562a94de28e4f67ddcf2c2c1037047a2848be217094487fa8"
   },
   "domain": "Stub",
   "files": [

--- a/scripts_manifest.json
+++ b/scripts_manifest.json
@@ -1,8 +1,9 @@
 {
-  "generated_at": "2025-09-19T05:11:29Z",
-  "git_commit": "5bd11e6ce6e27e41604b7b71f4dc94269cfb1e81",
+  "generated_at": "2025-09-23T10:41:55Z",
+  "git_commit": "da29ec9df2426cce6e815bf8f3c93f1dc53c8297",
   "files": [
     { "path": "core/hashing/sha256.js", "sha256": "b4f9db6546461662be8652ea40f0619f2d10ee14987fb8e46b58b5c25d216738" },
+    { "path": "core/metrics/request-metrics.js", "sha256": "2049892d9f2e44841f82ee7bcd3659317f2b940cd998b3fa5fd93cc78babf2aa" },
     { "path": "scripts/.node/node_modules/.package-lock.json", "sha256": "16314bb5d82087952ada77365dd282c93547d84e11b57595834dc9fde89bf7f4" },
     { "path": "scripts/.node/node_modules/ajv-formats/LICENSE", "sha256": "9df3bb69929a3b650ed73b3bfa1756725aaff0ac296461605753547004eafeaf" },
     { "path": "scripts/.node/node_modules/ajv-formats/README.md", "sha256": "94a341854ce2561e7484f927c65d4da699be47097964e97cfb044d8516b856a8" },


### PR DESCRIPTION
## WHAT
- Add shields-compatible engine health badge output and surface badge in README
- Log per-request totals and p95 latency via reusable metrics helper
- Refresh automation pins and scripts manifest after hash-all

## WHY
- Provide lightweight uptime badge and capture request latency evidence for audits

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>