### PR TITLE
feat(engine): serve health badge and metrics

### DIFF
--- a/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
+++ b/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "1c6f6a8e88377cfc1c5bac548587a263caff0ae5",
-    "scripts_manifest_sha256": "c94e2cea1413036424e225dc6b50a688bb3701e8df8f1d1a5427ef7561d944a9"
+    "repo_commit": "a3bfe10aa56987efb22a972cea8087e33df59099",
+    "scripts_manifest_sha256": "d73e0042136527e0579039981172872aadaa578737ce8cc7179dfe5e165b4028"
   },
   "domain": "Stub",
   "files": [

--- a/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "80a90d64d3f6ba202560d8f50d8243140a2f982157060e43d181f8a7860f690e"
   },
   "automation": {
-    "repo_commit": "1c6f6a8e88377cfc1c5bac548587a263caff0ae5",
-    "scripts_manifest_sha256": "c94e2cea1413036424e225dc6b50a688bb3701e8df8f1d1a5427ef7561d944a9"
+    "repo_commit": "a3bfe10aa56987efb22a972cea8087e33df59099",
+    "scripts_manifest_sha256": "d73e0042136527e0579039981172872aadaa578737ce8cc7179dfe5e165b4028"
   },
   "provenance": {
     "source_pdfs": [

--- a/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "80a90d64d3f6ba202560d8f50d8243140a2f982157060e43d181f8a7860f690e"
   },
   "automation": {
-    "repo_commit": "1c6f6a8e88377cfc1c5bac548587a263caff0ae5",
-    "scripts_manifest_sha256": "c94e2cea1413036424e225dc6b50a688bb3701e8df8f1d1a5427ef7561d944a9"
+    "repo_commit": "a3bfe10aa56987efb22a972cea8087e33df59099",
+    "scripts_manifest_sha256": "d73e0042136527e0579039981172872aadaa578737ce8cc7179dfe5e165b4028"
   },
   "provenance": {
     "author": "Fred Egbuedike",

--- a/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "1c6f6a8e88377cfc1c5bac548587a263caff0ae5",
-    "scripts_manifest_sha256": "c94e2cea1413036424e225dc6b50a688bb3701e8df8f1d1a5427ef7561d944a9"
+    "repo_commit": "a3bfe10aa56987efb22a972cea8087e33df59099",
+    "scripts_manifest_sha256": "d73e0042136527e0579039981172872aadaa578737ce8cc7179dfe5e165b4028"
   },
   "domain": "Stub",
   "files": [

--- a/scripts_manifest.json
+++ b/scripts_manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2025-09-23T12:52:43Z",
-  "git_commit": "1c6f6a8e88377cfc1c5bac548587a263caff0ae5",
+  "generated_at": "2025-09-23T15:31:53Z",
+  "git_commit": "a3bfe10aa56987efb22a972cea8087e33df59099",
   "files": [
     { "path": "core/hashing/sha256.js", "sha256": "b4f9db6546461662be8652ea40f0619f2d10ee14987fb8e46b58b5c25d216738" },
     { "path": "core/metrics/request-metrics.js", "sha256": "2049892d9f2e44841f82ee7bcd3659317f2b940cd998b3fa5fd93cc78babf2aa" },


### PR DESCRIPTION
  ## What
  - add /api/healthz alias to the adapter and serve a shields-compatible badge
  when ?badge=1
  - log health request totals and rolling p95 latency, appending to
  ENGINE_METRICS_LOG when configured
  - refresh META automation pins and scripts manifest after ./scripts/hash-
  all.sh

  ## Why
  - expose the engine health signal (with badge) and latency evidence without
  duplicating existing serverless work

  ## Tests
  - ./scripts/hash-all.sh
  - npm run validate:lean
  - ./scripts/check-registry.sh
  - ./scripts/check-lean-drift.sh

  Signed-off-by: Fred Egbuedike <fredilly@article6.org>
