### PR TITLE
feat(api): add manifest search endpoint

### DIFF
--- a/api/manifest.js
+++ b/api/manifest.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const { URL } = require('url');
+const { createEngine } = require('../bin/http-engine-adapter');
+
+let engine;
+
+function ensureEngine() {
+  if (!engine) {
+    engine = createEngine();
+  }
+  return engine;
+}
+
+function send(res, statusCode, payload) {
+  const body = JSON.stringify(payload);
+  res.statusCode = statusCode;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.setHeader('Content-Length', Buffer.byteLength(body));
+  res.end(body);
+}
+
+module.exports = async function handler(req, res) {
+  if ((req.method || 'GET').toUpperCase() !== 'GET') {
+    send(res, 405, { error: 'MethodNotAllowed', message: 'Use GET' });
+    return;
+  }
+
+  let query = '';
+  try {
+    const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+    query = (url.searchParams.get('q') || '').trim().toLowerCase();
+  } catch (err) {
+    send(res, 400, { error: 'InvalidRequest', message: 'Malformed URL' });
+    return;
+  }
+
+  const engineInstance = ensureEngine();
+  const docs = (engineInstance.documents || []).map((doc) => ({
+    doc_id: doc.key,
+    methodology_id: doc.methodology_id,
+    version: doc.version,
+    rule_id: doc.rule_id,
+    section_id: doc.section_id,
+    section_title: doc.section_title,
+    tags: doc.tags,
+    text: doc.text
+  }));
+
+  const filtered = query
+    ? docs.filter((entry) => {
+        const q = query;
+        const textMatch = entry.text && entry.text.toLowerCase().includes(q);
+        const tagsMatch = Array.isArray(entry.tags) && entry.tags.some((tag) => String(tag).toLowerCase().includes(q));
+        const versionMatch = entry.version && String(entry.version).toLowerCase().includes(q);
+        const methodMatch = entry.methodology_id && entry.methodology_id.toLowerCase().includes(q);
+        const ruleMatch = entry.rule_id && entry.rule_id.toLowerCase().includes(q);
+        const titleMatch = entry.section_title && entry.section_title.toLowerCase().includes(q);
+        return textMatch || tagsMatch || versionMatch || methodMatch || ruleMatch || titleMatch;
+      })
+    : docs;
+
+  send(res, 200, { rules: filtered, total: filtered.length });
+};

--- a/bin/http-engine-adapter.js
+++ b/bin/http-engine-adapter.js
@@ -222,7 +222,7 @@ function createEngine() {
     return { results, audit, topK: limit };
   }
 
-  return { search, audit };
+  return { search, audit, documents };
 }
 
 async function readRequestBody(req) {
@@ -327,6 +327,39 @@ function handleHealth(engine, req, res) {
   }
 }
 
+function handleManifest(engine, req, res) {
+  try {
+    const url = new URL(req.url, 'http://localhost');
+    const query = (url.searchParams.get('q') || '').trim().toLowerCase();
+    const docs = (engine.documents || []).map((doc) => ({
+      doc_id: doc.key,
+      methodology_id: doc.methodology_id,
+      version: doc.version,
+      rule_id: doc.rule_id,
+      section_id: doc.section_id,
+      section_title: doc.section_title,
+      tags: doc.tags,
+      text: doc.text
+    }));
+    const filtered = query
+      ? docs.filter((entry) => {
+          const q = query;
+          const textMatch = entry.text && entry.text.toLowerCase().includes(q);
+          const tagsMatch = Array.isArray(entry.tags) && entry.tags.some((tag) => String(tag).toLowerCase().includes(q));
+          const versionMatch = entry.version && String(entry.version).toLowerCase().includes(q);
+          const methodMatch = entry.methodology_id && entry.methodology_id.toLowerCase().includes(q);
+          const ruleMatch = entry.rule_id && entry.rule_id.toLowerCase().includes(q);
+          const titleMatch = entry.section_title && entry.section_title.toLowerCase().includes(q);
+          return textMatch || tagsMatch || versionMatch || methodMatch || ruleMatch || titleMatch;
+        })
+      : docs;
+    sendJSON(res, 200, { rules: filtered, total: filtered.length });
+  } catch (err) {
+    console.warn('[engine] manifest error', err && err.message ? err.message : err);
+    sendJSON(res, 400, { error: 'InvalidRequest', message: 'Malformed manifest request' });
+  }
+}
+
 async function handleQuery(engine, req, res) {
   try {
     const rawBody = await readRequestBody(req);
@@ -373,6 +406,10 @@ function startServer(engine, options = {}) {
         const url = new URL(req.url, 'http://localhost');
         if (url.pathname === '/healthz' || url.pathname === '/api/healthz') {
           handleHealth(engine, req, res);
+          return;
+        }
+        if (url.pathname === '/manifest' || url.pathname === '/api/manifest') {
+          handleManifest(engine, req, res);
           return;
         }
       } catch (err) {


### PR DESCRIPTION
## WHAT
- Add `/api/manifest` handler (and CLI parity) that returns all rule entries with optional `?q` filter across `text`, `tags`, `version`, `method`, `rule ID`, and `section title`
- Expose engine documents from `createEngine` so manifest can reuse cached corpus

## WHY
- Enable clients to retrieve filtered manifest data without limiting to top 5 results

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>
