### PR TITLE
feat(engine): auto-discover corpus for manifest

### DIFF
--- a/api/manifest.js
+++ b/api/manifest.js
@@ -27,9 +27,12 @@ module.exports = async function handler(req, res) {
   }
 
   let query = '';
+  let returnAll = false;
   try {
     const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
     query = (url.searchParams.get('q') || '').trim().toLowerCase();
+    const allParam = (url.searchParams.get('all') || '').trim().toLowerCase();
+    returnAll = allParam === '1' || allParam === 'true' || allParam === 'yes';
   } catch (err) {
     send(res, 400, { error: 'InvalidRequest', message: 'Malformed URL' });
     return;
@@ -60,5 +63,7 @@ module.exports = async function handler(req, res) {
       })
     : docs;
 
-  send(res, 200, { rules: filtered, total: filtered.length });
+  const output = returnAll ? docs : filtered;
+
+  send(res, 200, { rules: output, total: output.length });
 };

--- a/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
+++ b/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "71105651e24526f17384b0540045c9749d5c37c3",
-    "scripts_manifest_sha256": "65e45d701caa14154a2293770338d3f6e2a9a7f1d4502563eb961a37668bb125"
+    "repo_commit": "54054f933a6daf653bd9692a5363792f503ca983",
+    "scripts_manifest_sha256": "60caacc26f00e38647b6147dba18a0471ab26df4a7484ae8436b10854613ea9c"
   },
   "domain": "Stub",
   "files": [

--- a/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "80a90d64d3f6ba202560d8f50d8243140a2f982157060e43d181f8a7860f690e"
   },
   "automation": {
-    "repo_commit": "71105651e24526f17384b0540045c9749d5c37c3",
-    "scripts_manifest_sha256": "65e45d701caa14154a2293770338d3f6e2a9a7f1d4502563eb961a37668bb125"
+    "repo_commit": "54054f933a6daf653bd9692a5363792f503ca983",
+    "scripts_manifest_sha256": "60caacc26f00e38647b6147dba18a0471ab26df4a7484ae8436b10854613ea9c"
   },
   "provenance": {
     "source_pdfs": [

--- a/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "80a90d64d3f6ba202560d8f50d8243140a2f982157060e43d181f8a7860f690e"
   },
   "automation": {
-    "repo_commit": "71105651e24526f17384b0540045c9749d5c37c3",
-    "scripts_manifest_sha256": "65e45d701caa14154a2293770338d3f6e2a9a7f1d4502563eb961a37668bb125"
+    "repo_commit": "54054f933a6daf653bd9692a5363792f503ca983",
+    "scripts_manifest_sha256": "60caacc26f00e38647b6147dba18a0471ab26df4a7484ae8436b10854613ea9c"
   },
   "provenance": {
     "author": "Fred Egbuedike",

--- a/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "71105651e24526f17384b0540045c9749d5c37c3",
-    "scripts_manifest_sha256": "65e45d701caa14154a2293770338d3f6e2a9a7f1d4502563eb961a37668bb125"
+    "repo_commit": "54054f933a6daf653bd9692a5363792f503ca983",
+    "scripts_manifest_sha256": "60caacc26f00e38647b6147dba18a0471ab26df4a7484ae8436b10854613ea9c"
   },
   "domain": "Stub",
   "files": [

--- a/scripts_manifest.json
+++ b/scripts_manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2025-09-25T13:07:27Z",
-  "git_commit": "71105651e24526f17384b0540045c9749d5c37c3",
+  "generated_at": "2025-09-25T15:14:28Z",
+  "git_commit": "54054f933a6daf653bd9692a5363792f503ca983",
   "files": [
     { "path": "core/hashing/sha256.js", "sha256": "b4f9db6546461662be8652ea40f0619f2d10ee14987fb8e46b58b5c25d216738" },
     { "path": "core/metrics/request-metrics.js", "sha256": "2049892d9f2e44841f82ee7bcd3659317f2b940cd998b3fa5fd93cc78babf2aa" },


### PR DESCRIPTION
## WHAT
- Scan `methodologies/**/rules.json` to build `engine.documents` dynamically
- Extend `/api/manifest` (and CLI manifest) with `all=1` flag and full-field filtering
- Refresh automation hashes after `hash-all`

## WHY
- Expose complete corpus (dozens of rules) via manifest endpoint

**Signed-off-by:** Fred Egbuedike <fredilly@article6.org>