### PR TITLE
Agriculture derive tooling; add rich/lean automation

### DIFF
--- a/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
+++ b/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "bc0d78a08d834aa4a685818ff9622ff38489e7c2",
-    "scripts_manifest_sha256": "0391a85fb6d50e2ebff4155c21f43e1bfe0773bb8827ec6786077de5a2db4ee3"
+    "repo_commit": "e5895b3b7b91d071f8f920bf1c68b99019ec9180",
+    "scripts_manifest_sha256": "cf15cad6a5882c25239501f362b2d2fa61c236cee184545632287bf8c98c1e90"
   },
   "domain": "Stub",
   "files": [

--- a/methodologies/UNFCCC/Forestry/AR-ACM0003/v02-0/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-ACM0003/v02-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "f35fc63ea03a21a81da4a23e3f2430ff5abe5fd95692413cb7b691f61317d71b"
   },
   "automation": {
-    "repo_commit": "bc0d78a08d834aa4a685818ff9622ff38489e7c2",
-    "scripts_manifest_sha256": "0391a85fb6d50e2ebff4155c21f43e1bfe0773bb8827ec6786077de5a2db4ee3"
+    "repo_commit": "e5895b3b7b91d071f8f920bf1c68b99019ec9180",
+    "scripts_manifest_sha256": "cf15cad6a5882c25239501f362b2d2fa61c236cee184545632287bf8c98c1e90"
   },
   "provenance": {
     "author": "Fred Egbuedike",

--- a/methodologies/UNFCCC/Forestry/AR-AM0014/v03-0/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AM0014/v03-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "4b9f1e1c6c2e57a48e9119a63c0c0c5b7cc0bf87ee041e679acadd0bd3e76b60"
   },
   "automation": {
-    "repo_commit": "bc0d78a08d834aa4a685818ff9622ff38489e7c2",
-    "scripts_manifest_sha256": "0391a85fb6d50e2ebff4155c21f43e1bfe0773bb8827ec6786077de5a2db4ee3"
+    "repo_commit": "e5895b3b7b91d071f8f920bf1c68b99019ec9180",
+    "scripts_manifest_sha256": "cf15cad6a5882c25239501f362b2d2fa61c236cee184545632287bf8c98c1e90"
   },
   "provenance": {
     "author": "Fred Egbuedike",

--- a/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0003/v01-0/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "80a90d64d3f6ba202560d8f50d8243140a2f982157060e43d181f8a7860f690e"
   },
   "automation": {
-    "repo_commit": "bc0d78a08d834aa4a685818ff9622ff38489e7c2",
-    "scripts_manifest_sha256": "0391a85fb6d50e2ebff4155c21f43e1bfe0773bb8827ec6786077de5a2db4ee3"
+    "repo_commit": "e5895b3b7b91d071f8f920bf1c68b99019ec9180",
+    "scripts_manifest_sha256": "cf15cad6a5882c25239501f362b2d2fa61c236cee184545632287bf8c98c1e90"
   },
   "provenance": {
     "source_pdfs": [

--- a/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
+++ b/methodologies/UNFCCC/Forestry/AR-AMS0007/v03-1/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "80a90d64d3f6ba202560d8f50d8243140a2f982157060e43d181f8a7860f690e"
   },
   "automation": {
-    "repo_commit": "bc0d78a08d834aa4a685818ff9622ff38489e7c2",
-    "scripts_manifest_sha256": "0391a85fb6d50e2ebff4155c21f43e1bfe0773bb8827ec6786077de5a2db4ee3"
+    "repo_commit": "e5895b3b7b91d071f8f920bf1c68b99019ec9180",
+    "scripts_manifest_sha256": "cf15cad6a5882c25239501f362b2d2fa61c236cee184545632287bf8c98c1e90"
   },
   "provenance": {
     "author": "Fred Egbuedike",

--- a/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-6/META.json
@@ -4,8 +4,8 @@
     "sections_json_sha256": "71e76af99f13c08c01c7ae879f476ac55557a93dd954a8c20027c5079d935c91"
   },
   "automation": {
-    "repo_commit": "bc0d78a08d834aa4a685818ff9622ff38489e7c2",
-    "scripts_manifest_sha256": "0391a85fb6d50e2ebff4155c21f43e1bfe0773bb8827ec6786077de5a2db4ee3"
+    "repo_commit": "e5895b3b7b91d071f8f920bf1c68b99019ec9180",
+    "scripts_manifest_sha256": "cf15cad6a5882c25239501f362b2d2fa61c236cee184545632287bf8c98c1e90"
   },
   "domain": "Stub",
   "files": [

--- a/scripts/derive-lean.sh
+++ b/scripts/derive-lean.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+need(){ command -v "$1" >/dev/null || { echo "Missing: $1"; exit 1; }; }
+need jq
+while IFS= read -r -d '' dir; do
+  rich_sections="$dir/sections.rich.json"
+  rich_rules="$dir/rules.rich.json"
+  if [ -f "$rich_sections" ]; then
+    jq '[ .[] | {id,number,title,level,page_start,page_end} ]' "$rich_sections" > "$dir/sections.json"
+  fi
+  if [ -f "$rich_rules" ]; then
+    jq '[ .[] | {id,section_id,type,page,text} ]' "$rich_rules" > "$dir/rules.json"
+  fi
+done < <(find methodologies -type d -name 'v*-*' -print0 | sort -z)
+echo "[derive-lean] done."

--- a/scripts/derive-rich.sh
+++ b/scripts/derive-rich.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+need(){ command -v "$1" >/dev/null || { echo "Missing: $1"; exit 1; }; }
+need jq
+need python3
+found=0
+while IFS= read -r -d '' dir; do
+  rel="${dir#methodologies/}"
+  IFS='/' read -r publisher sector method version <<<"$rel"
+  meta="$dir/META.json"
+  pdf=""
+  if [ -f "$meta" ]; then
+    pdf=$(jq -r '(.references.pdf.path // "")' "$meta")
+  fi
+  if [ -z "$pdf" ]; then
+    pdf="tools/${publisher}/${method}/${version}/source.pdf"
+  fi
+  if [ ! -f "$pdf" ]; then
+    echo "[skip] no pdf for $dir"
+    continue
+  fi
+  found=1
+  python3 scripts/derive_rich.py \
+    --pdf "$pdf" \
+    --out-sections "$dir/sections.rich.json" \
+    --out-rules "$dir/rules.rich.json"
+  jq -e 'type=="array" and length>0' "$dir/sections.rich.json" >/dev/null
+  jq -e 'type=="array" and length>0' "$dir/rules.rich.json" >/dev/null
+done < <(find methodologies -type d -name 'v*-*' -print0 | sort -z)
+if [ "$found" -eq 0 ]; then
+  echo "[warn] no version dirs found"
+fi
+echo "[derive] done."

--- a/scripts/derive_rich.py
+++ b/scripts/derive_rich.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import re
+from pathlib import Path
+
+from pdfminer.high_level import extract_pages
+from pdfminer.layout import LTTextContainer, LTTextLine
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pdf", required=True)
+    parser.add_argument("--out-sections", required=True)
+    parser.add_argument("--out-rules", required=True)
+    return parser.parse_args()
+
+
+def iter_page_text(pdf):
+    pages = []
+    for layout in extract_pages(pdf):
+        buffer = []
+        for element in layout:
+            if isinstance(element, LTTextContainer):
+                for line in element:
+                    if isinstance(line, LTTextLine):
+                        text = line.get_text().rstrip("\n")
+                        if text.strip():
+                            buffer.append(text)
+        pages.append("\n".join(buffer))
+    return pages
+
+
+def detect_headings(lines):
+    head = re.compile(r"^([0-9]+(?:\.[0-9]+)*)\s+(.+)$")
+    ann = re.compile(r"^(Annex|Appendix)\s+[A-Z0-9]+(?:\.|:)?.+$")
+    caps = re.compile(r"^[A-Z][A-Z0-9 ,\-–()]{6,}$")
+    headings = []
+    for index, line in enumerate(lines):
+        match = head.match(line)
+        title = None
+        number = None
+        if match and match.group(2).strip():
+            number = match.group(1)
+            title = match.group(2).strip()
+        elif ann.match(line):
+            title = line.strip()
+        elif caps.match(line) and len(line.split()) >= 2:
+            title = line.strip()
+        if title:
+            headings.append((index, number, title))
+    if not headings or headings[0][0] != 0:
+        headings = [(0, None, "Prelude")] + headings
+    return headings
+
+
+def build_bounds(pages):
+    bounds = []
+    total = 0
+    for page in pages:
+        count = len(page.splitlines())
+        bounds.append((total, total + count))
+        total += count
+    return bounds
+
+
+def line_to_page(bounds, index):
+    for page_number, (start, end) in enumerate(bounds):
+        if start <= index < end:
+            return page_number + 1
+    return max(1, len(bounds))
+
+
+def slice_sections(lines, headings, bounds):
+    sections = []
+    for offset, (start, number, title) in enumerate(headings):
+        end = headings[offset + 1][0] if offset + 1 < len(headings) else len(lines)
+        body = lines[start + 1 : end]
+        text = "\n".join(body).strip()
+        page_start = line_to_page(bounds, start + 1 if start + 1 < len(lines) else start)
+        page_end = line_to_page(bounds, end - 1 if end - 1 >= 0 else start)
+        level = 1 if (number is None or "." not in str(number)) else 2
+        anchors = [word.lower() for word in re.findall(r"[A-Za-z]{4,}", title)][:3]
+        sections.append(
+            {
+                "id": f"S-{offset + 1}",
+                "number": number,
+                "title": title,
+                "level": level,
+                "page_start": page_start,
+                "page_end": page_end,
+                "text": text,
+                "anchors": anchors,
+            }
+        )
+    return sections
+
+
+def classify(text):
+    sample = text.lower()
+    if "baseline" in sample:
+        return "baseline"
+    if any(keyword in sample for keyword in ["monitor", "measure", "record", "qa/qc"]):
+        return "monitoring"
+    if "leakage" in sample:
+        return "leakage"
+    if any(keyword in sample for keyword in ["additionality", "barrier", "common practice"]):
+        return "additionality"
+    return "unspecified"
+
+
+def extract_rules(sections):
+    keyword = re.compile(r"\b(shall|must|required|monitor|measure|record|baseline|leakage|additionality)\b", re.IGNORECASE)
+    bullet = re.compile(r"^\s*(?:[-\u2022\*]|[0-9]+\.|[a-z]\))\s+")
+    rules = []
+    counter = 1
+
+    def flush(chunk, section):
+        nonlocal counter
+        text = chunk.strip()
+        if not text or not keyword.search(text):
+            return
+        rules.append(
+            {
+                "id": f"R-{section['id']}-{counter:03d}",
+                "section_id": section["id"],
+                "label": text.split(".")[0][:120],
+                "type": classify(text),
+                "page": section["page_start"],
+                "text": text,
+                "citations": [],
+                "source": {"pdf": "source.pdf"},
+            }
+        )
+        counter += 1
+
+    for section in sections:
+        buffer = []
+        lines = section["text"].splitlines()
+        for line in lines:
+            if bullet.match(line):
+                flush(" ".join(buffer), section)
+                buffer = [bullet.sub("", line)]
+            else:
+                buffer.append(line)
+                if line.strip().endswith("."):
+                    flush(" ".join(buffer), section)
+                    buffer = []
+        flush(" ".join(buffer), section)
+    return rules
+
+
+def main():
+    args = parse_args()
+    pages = iter_page_text(args.pdf)
+    lines = [value.rstrip() for value in "\n".join(pages).splitlines()]
+    headings = detect_headings(lines)
+    bounds = build_bounds(pages)
+    sections = slice_sections(lines, headings, bounds)
+    rules = extract_rules(sections)
+    Path(args.out_sections).parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out_sections, "w", encoding="utf-8") as handle:
+        json.dump(sections, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+    with open(args.out_rules, "w", encoding="utf-8") as handle:
+        json.dump(rules, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ingest.sh
+++ b/scripts/ingest.sh
@@ -186,4 +186,11 @@ for i in $(seq 0 $((method_count-1))); do
   echo "[done] $id $ver"
 done
 
+# auto-derive rich if available
+if [ -x ./scripts/derive-rich.sh ]; then
+  ./scripts/derive-rich.sh
+else
+  echo "[note] derive-rich.sh not found; rich files will remain stubs"
+fi
+
 echo "✅ ingest complete"

--- a/scripts_manifest.json
+++ b/scripts_manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2025-10-12T12:02:32Z",
-  "git_commit": "bc0d78a08d834aa4a685818ff9622ff38489e7c2",
+  "generated_at": "2025-10-13T06:01:03Z",
+  "git_commit": "e5895b3b7b91d071f8f920bf1c68b99019ec9180",
   "files": [
     { "path": "core/hashing/sha256.js", "sha256": "b4f9db6546461662be8652ea40f0619f2d10ee14987fb8e46b58b5c25d216738" },
     { "path": "core/metrics/request-metrics.js", "sha256": "2049892d9f2e44841f82ee7bcd3659317f2b940cd998b3fa5fd93cc78babf2aa" },
@@ -22,6 +22,9 @@
     { "path": "scripts/compile-audit.js", "sha256": "917ee7d5fabef37ec7d4bfa9503ac498da225426bf5fbd05fd710d35699a1a14" },
     { "path": "scripts/compile-validators.js", "sha256": "0d6d8454097445711c1a0f974061f7f426522b8c1e1c0b61998cfa1c2237949b" },
     { "path": "scripts/derive-lean-from-rich.js", "sha256": "522e798bcbbf3e8261454dc104a4287b774f1157b890cf798571571698d608b9" },
+    { "path": "scripts/derive-lean.sh", "sha256": "44daa155e5447dae09f271c2c04303dfd871d769a861fe9c8992d441bde4d621" },
+    { "path": "scripts/derive-rich.sh", "sha256": "caf157ed0b955f6e0229baaf8a7cf08b8da913b2f4b3778cee962b959e97ae6b" },
+    { "path": "scripts/derive_rich.py", "sha256": "6070afac1cd8e2653843fc71168e9bcc830e6ca8789e172253598c28394164eb" },
     { "path": "scripts/fill-provenance.js", "sha256": "ada54506b8554fd101c56541768bbec912d9050842734c2f97a153b9d067b221" },
     { "path": "scripts/gen-dataset-params.js", "sha256": "befe8d1bdece5b2738284c2b60598e676f7f910c605ffb53fbb7a07c3342414f" },
     { "path": "scripts/gen-dataset.js", "sha256": "47b58f5dc13beded4ece8a74029827669945ae5140b2dfec4a8f19894d3cc753" },
@@ -29,7 +32,7 @@
     { "path": "scripts/gen-registry.js", "sha256": "ed5e27b27860ae358c20c1d0e2cd15c678cd021a50ef295ff0234603f00c8b0e" },
     { "path": "scripts/hash-all.sh", "sha256": "fabde300b13955637938a3fb95e41b41f8aca2da8257baf16feb8beed4c3ec03" },
     { "path": "scripts/hash-scripts.sh", "sha256": "ee774cb19ed6f38c8edaeaa048d008e8759d512438946f7740ff79f79a7071a3" },
-    { "path": "scripts/ingest.sh", "sha256": "8c9ea564475e79fa829d07937a31b457e8a4b57f8c8b97bc1644a26cf421af2f" },
+    { "path": "scripts/ingest.sh", "sha256": "45fda9eaa9f941c9a336e855b33b006153b1a9a35734faff0a3c7a00fa9c3863" },
     { "path": "scripts/inject-anchors.js", "sha256": "0541bc16ebc87a2cb54c2b8b251e96d64512a6e8607ed70948195af4f6fc2953" },
     { "path": "scripts/install-hooks.sh", "sha256": "fcd91a8dc76ea68cf703f388c0fc99282f8cefacd30e348ca27a238049123ac3" },
     { "path": "scripts/install-vendored-ajv.sh", "sha256": "58d98426bb0dc94f73e53d535495d629df276e876534ffb2d8227557f4ccfc2c" },


### PR DESCRIPTION
## What
- add `scripts/derive_rich.py` plus shell wrappers to populate rich and lean methodology artefacts
- wire the derive step into `scripts/ingest.sh` and refresh the scripts manifest + automation pins

## Why
- prepare the agriculture ingest batch to emit non-stub rich/lean data straight from the pipeline

## Testing
- `./scripts/hash-all.sh`
- `./scripts/json-canonical-check.sh --fix`
- `./scripts/ci-run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68ec9376c4a08331a7ad426b8f5c0dbb