### PR TITLE
chore: add rich-rule v1 contract follow-up to requirement-coverage roadmap

### DIFF
--- a/docs/roadmaps/requirement-coverage-support/ROADMAP.md
+++ b/docs/roadmaps/requirement-coverage-support/ROADMAP.md
@@ -61,6 +61,13 @@ Make canonical methodology outputs rich enough to support requirement-to-evidenc
 - Keep `ingest.sh`, CI, and workflows as the execution layer, phased in later only when schema and output contracts are stable enough to support automation safely.
 - Any automation hardening must remain scoped, reviewable, and friendly to strict repository gates rather than becoming a broad first move.
 
+### RC-S8 — Lock rich-rule v1 contract
+
+- Lock the rich-rule v1 baseline contract to `summary`, `logic`, `notes`, `when`, `refs`, and `requirement_coverage.expected_evidence` where grounded.
+- Treat duplicate or empty `display.*` fields as out of contract for the baseline and do not reintroduce cleanup churn around them.
+- Future methodology work in this area should be additive enrichment only, not another round of field-shape cleanup.
+- Additive enrichment examples include provenance excerpts, failure modes, review questions, and broader `expected_evidence` coverage where grounded.
+
 ## Delivery constraints
 
 - Do not build app UI here.

--- a/docs/roadmaps/requirement-coverage-support/phase-status.json
+++ b/docs/roadmaps/requirement-coverage-support/phase-status.json
@@ -1,6 +1,6 @@
 {
   "goal": "Make methodology outputs rich enough to support requirement-to-evidence reconciliation in the app.",
-  "last_updated_at": "2026-04-03T06:30:00Z",
+  "last_updated_at": "2026-04-04T00:00:00Z",
   "phases": [
     {
       "id": "rc-s1-rich-schema-foundation",
@@ -36,6 +36,11 @@
       "id": "rc-s7-ingestion-automation-hardening-later",
       "name": "Ingestion automation hardening later",
       "status": "done"
+    },
+    {
+      "id": "rc-s8-lock-rich-rule-v1-contract",
+      "name": "Lock rich-rule v1 contract",
+      "status": "planned"
     }
   ],
   "roadmap": "requirement-coverage-support"


### PR DESCRIPTION

WHAT:
- add RC-S8 to lock the cleaned rich-rule v1 contract as the baseline
- record that future methodology work should be additive enrichment only
- update roadmap phase tracking for the new planned phase

WHY:
- the rich-rule cleanup should be done once and reused across methods
- requirement-coverage rollout needs a stable app-facing contract baseline
- future work should add signal instead of reopening field-shape churn

## WHAT

- Concise scope for the change plus the most important files/paths touched.
- Mention whether golden fixtures or Root Cause Template entries are affected.
- Snapshot of behavior changes (CI gates, determinism, ingest flow).

## WHY

- Motivation, risk, and determinism/integrity impact (hashes, schema, registry).
- Alternatives considered and why they were rejected.
- Links/issues, stakeholder drivers, or SLAs touched.

## CHANGES

- Bullet list of technical changes (scripts, schemas, ingest runners, CI).
- Commands/tests run, including the double-run health check if applicable.
- Hash/schema/registry validation evidence.

## ACCEPTANCE

- Expected reviewer/CI checks and how to reproduce them.
- Link/reference relevant Root Cause Template entries or new invariants.
- State Agriculture/Forestry fixture status (still green?) and regression risk.

Signed-off-by: Fred E <fredilly@article6.org>
