### PR TITLE
docs: traceable-rule-review-mvp roadmap (T-1 through T-5)

### DIFF
--- a/docs/roadmaps/complete-methodology-coverage/ROADMAP.md
+++ b/docs/roadmaps/complete-methodology-coverage/ROADMAP.md
@@ -1,0 +1,134 @@
+# Complete Methodology Coverage
+
+Status is sourced from `phase-status.json`.
+
+## Goal
+
+Encode enough methodologies so the app can serve any VVB working with UNFCCC CDM forestry and agriculture methods. The app roadmap (verifiable-review-record) consumes these outputs — this repo supplies the data.
+
+## What's already done
+
+Rich rule schemas (RC-S1 through RC-S7) are locked. AR-ACM0003 v02-0 is encoded with rich rules, sections, and version lineage. Several agriculture methods are ingested. Manifest generation works.
+
+## What's needed
+
+The app's VRR-4 milestone requires at least 2 methodologies loadable (AR-ACM0003 + one agriculture method). VVB pilots will want their specific methodology. Encoding must be fast and repeatable.
+
+## Parallel dependency
+
+This roadmap feeds directly into `app.article6/docs/roadmaps/verifiable-review-record`. VRR-1 (review surface) is app-only. VRR-2+ need methodology data to be complete.
+
+---
+
+## CMC-1 — AR-ACM0003 Completeness (Week 1)
+
+### Goal
+
+Ensure AR-ACM0003 v02-0 has everything the app needs for the review surface.
+
+### Deliverables
+
+- Verify `rules.rich.json` has `text`, `logic`, `refs`, and `tags` for every rule
+- Verify `sections.rich.json` has stable anchors for all sections
+- Verify `META.json` has correct tool references and hashes
+- Fix any gaps found during verification
+- Run all existing AR-ACM0003 tests — must pass green
+
+### Acceptance criteria
+
+- [ ] Every rule in `rules.rich.json` has non-empty `text` field
+- [ ] Section anchors resolve to valid PDF locations
+- [ ] All AR-ACM0003 CI tests pass
+- [ ] Manifest index.json includes AR-ACM0003 v02-0
+
+---
+
+## CMC-2 — One Agriculture Methodology (Week 2)
+
+### Goal
+
+Encode one complete agriculture methodology end-to-end so the app can demonstrate multi-methodology support.
+
+### Deliverables
+
+- Pick the best candidate from existing ingests (ACM0010 or AMS-III.A — whichever is most complete)
+- Encode full `rules.rich.json` with text, logic, refs, tags
+- Encode `sections.rich.json` with stable anchors
+- Generate `META.json` with tool references
+- Run CI — must pass all gates
+
+### Selection criteria
+
+- Most rules (max coverage for demo)
+- Has multiple versions (version lineage support)
+- Already has some ingest data in `batches/`
+
+### Acceptance criteria
+
+- [ ] Selected methodology has `rules.rich.json` with all rules populated
+- [ ] Section anchors valid
+- [ ] CI passes
+- [ ] Manifest index.json includes the methodology
+- [ ] App can load and display it alongside AR-ACM0003
+
+---
+
+## CMC-3 — Encoding Playbook (Week 3)
+
+### Goal
+
+Document the encoding process so new methodologies can be added in <1 day each. VVB pilots will bring their own methods.
+
+### Deliverables
+
+- Step-by-step encoding guide in `docs/ingest/ENCODING_PLAYBOOK.md`
+- Template files for new methodology onboarding
+- Checklist: what to verify before marking a methodology as "app-ready"
+- Example: encode a second methodology using the playbook to validate it
+
+### Acceptance criteria
+
+- [ ] Playbook exists and covers: PDF source → sections → rules → rich → META → manifest
+- [ ] Template files in `templates/` are up to date
+- [ ] A new methodology can be encoded following only the playbook (tested)
+- [ ] "App-ready" checklist has 5+ verification steps
+
+---
+
+## CMC-4 — Batch Encoding for Pilots (Weeks 4-5)
+
+### Goal
+
+Encode the top 3-5 methodologies that VVB pilots are most likely to request.
+
+### Deliverables
+
+- Encode AR-AM0014 (forestry, v02-0) — second forestry method
+- Encode ACM0010 (agriculture, v03-0) — most-used agriculture method
+- Encode one more based on pilot demand
+- All pass CI gates
+- Manifest includes all encoded methodologies
+
+### Acceptance criteria
+
+- [ ] 3+ methodologies fully encoded and app-ready
+- [ ] All CI tests pass
+- [ ] Manifest index.json complete
+- [ ] App can switch between methodologies seamlessly
+
+---
+
+## Always-optimizing
+
+1. **Data quality over quantity** — one perfect methodology beats three incomplete ones
+2. **Stable IDs are sacred** — never change a rule_id or section_id after encoding
+3. **Lean + rich separation** — keep rules.json thin, rules.rich.json rich
+4. **CI gates are the contract** — if CI passes, the app can consume it
+5. **Encoding speed matters** — VVB pilots can't wait 2 weeks for their methodology
+
+## What this roadmap excludes
+
+- New methodology sources (Gold Standard is lower priority than UNFCCC for Article 6)
+- Schema redesign (RC-S1-S7 locked the contract)
+- App UI work (that's the app repo's job)
+- Document extraction (that's app-side VRR-3)

--- a/docs/roadmaps/complete-methodology-coverage/phase-status.json
+++ b/docs/roadmaps/complete-methodology-coverage/phase-status.json
@@ -1,0 +1,56 @@
+{
+  "roadmap": "complete-methodology-coverage",
+  "goal": "Encode enough methodologies so the app can serve any VVB working with UNFCCC CDM forestry and agriculture methods.",
+  "last_updated_at": "2026-04-15T00:00:00Z",
+  "status": "active",
+  "parallel_dependency": "app.article6/docs/roadmaps/verifiable-review-record",
+  "current_focus": ["CMC-1: AR-ACM0003 Completeness"],
+  "phases": [
+    {
+      "id": "cmc-1-ar-acm0003-completeness",
+      "name": "AR-ACM0003 Completeness",
+      "week": 1,
+      "status": "active"
+    },
+    {
+      "id": "cmc-2-one-agriculture-methodology",
+      "name": "One Agriculture Methodology",
+      "week": 2,
+      "status": "planned",
+      "depends_on": ["cmc-1-ar-acm0003-completeness"]
+    },
+    {
+      "id": "cmc-3-encoding-playbook",
+      "name": "Encoding Playbook",
+      "week": 3,
+      "status": "planned",
+      "depends_on": ["cmc-2-one-agriculture-methodology"]
+    },
+    {
+      "id": "cmc-4-batch-encoding-for-pilots",
+      "name": "Batch Encoding for Pilots",
+      "weeks": "4-5",
+      "status": "planned",
+      "depends_on": ["cmc-3-encoding-playbook"]
+    }
+  ],
+  "pr_evidence": {},
+  "pr_meta": {
+    "CMC-1": {
+      "title": "AR-ACM0003 Completeness",
+      "summary": "Verify and fix AR-ACM0003 v02-0 so every rule has text, logic, refs, and valid section anchors."
+    },
+    "CMC-2": {
+      "title": "One Agriculture Methodology",
+      "summary": "Encode one complete agriculture methodology end-to-end for multi-methodology demo."
+    },
+    "CMC-3": {
+      "title": "Encoding Playbook",
+      "summary": "Document the encoding process so new methodologies can be added in <1 day."
+    },
+    "CMC-4": {
+      "title": "Batch Encoding for Pilots",
+      "summary": "Encode top 3-5 methodologies VVB pilots are most likely to request."
+    }
+  }
+}

--- a/docs/roadmaps/traceable-rule-review-mvp/ROADMAP.md
+++ b/docs/roadmaps/traceable-rule-review-mvp/ROADMAP.md
@@ -1,0 +1,218 @@
+# Traceable Rule Review MVP
+
+Status: `docs/roadmaps/traceable-rule-review-mvp/phase-status.json`.
+
+## Goal
+
+Provide canonical rule contract support so the app can build a traceable rule review workspace. This repo owns **methodology semantics, schema definitions, and data quality**. It does NOT own UI, workflow, persistence, or export execution. That is the app repo.
+
+Cross-reference: [app roadmap](https://github.com/Fredilly/app.article6/tree/main/docs/roadmaps/traceable-rule-review-mvp).
+
+## Repo boundary
+
+This roadmap defines what methodology data must contain for the app to consume it. Schema contracts, rule metadata quality, and evidence type definitions live here. Implementation of review UI, API endpoints, and export logic lives in the app repo.
+
+## How existing pieces fit
+
+| Piece | Current state | Contract responsibility here |
+|-------|--------------|------------------------------|
+| **Methods** | `rules.rich.json` with id, summary, logic, type, refs, tags, when | Must provide: text for display, section anchors for navigation, type for STAC eligibility filtering |
+| **Complex methods** | Version lineage (RC-S5), diff metadata | Must provide: stable IDs across versions, version relationship metadata |
+| **AOI** | App-side only | No contract work needed — app handles AOI geometry |
+| **STAC eligibility** | Tags exist (`monitoring`, `baseline`, `emissions`) but no explicit STAC flag | Must define: which rule types/tags indicate satellite evidence eligibility |
+| **Evidence types** | `requirement_coverage.expected_evidence` in schema (RC-S6) | Must populate: structured evidence hints per rule |
+| **Manual review flags** | `requirement_kind` field exists but sparse | Must populate: which rules require human judgment vs. calculable |
+
+## Priority
+
+truthfulness > defensibility > clean repo boundaries > data completeness
+
+## Phases
+
+All five phases are strict. Each builds on the previous. Phase IDs and titles match the app repo exactly.
+
+---
+
+## T-1 — Rule Review Record (data contract)
+
+### Goal
+
+Ensure every rule has the minimum data the app needs to display a review panel.
+
+### Contract requirements
+
+- `text` or `summary` — non-empty string the app displays as the rule's requirement
+- `refs.section_anchor` — valid anchor linking to the methodology PDF section
+- `refs.primary_section` — section ID for navigation
+- `type` — one of: eligibility, parameter, equation, calc, monitoring, leakage, uncertainty, reporting
+- `tags` — array of strings for filtering (existing: baseline, emissions)
+- `id` and `stable_id` — both present and consistent
+
+### What to verify/fix
+
+- Every rule in AR-ACM0003 v02-0 `rules.rich.json` has non-empty text/summary
+- Section anchors in `sections.rich.json` resolve to valid positions
+- `META.json` references are complete
+
+### Files to check
+
+- `methodologies/UNFCCC/Forestry/AR-ACM0003/v02-0/rules.rich.json`
+- `methodologies/UNFCCC/Forestry/AR-ACM0003/v02-0/sections.rich.json`
+- `methodologies/UNFCCC/Forestry/AR-ACM0003/v02-0/META.json`
+
+### Acceptance criteria
+
+- [ ] Every rule has non-empty `summary` or equivalent display text
+- [ ] Every rule has `refs.section_anchor`
+- [ ] Every rule has a valid `type`
+- [ ] Section anchors resolve to existing sections
+- [ ] All CI tests pass
+
+---
+
+## T-2 — Defensible Verification (evidence contract)
+
+### Goal
+
+Define what evidence types are supportable per rule type. The app uses this to know what fields to show.
+
+### Contract requirements
+
+- Populate `requirement_coverage.expected_evidence` for rules where grounded
+- Define evidence type taxonomy:
+  - `monitoring_report` — periodic project reports
+  - `satellite_imagery` — STAC-sourced scenes
+  - `calculation_workbook` — baseline/removals/leakage spreadsheets
+  - `project_document` — PDD, methodology documents
+  - `field_measurement` — on-site measurements
+  - `third_party_verification` — prior audit findings
+- Map rule types to expected evidence types (e.g., `monitoring` rules expect `monitoring_report` + `satellite_imagery`)
+- Populate `requirement_kind` to distinguish: human-judgment-required vs. calculable vs. document-check
+
+### Files to modify
+
+- `schemas/rules.rich.schema.json` — ensure evidence type enum if needed
+- `methodologies/UNFCCC/Forestry/AR-ACM0003/v02-0/rules.rich.json` — populate expected_evidence where grounded
+- `docs/ingest/ENCODING_PLAYBOOK.md` — document evidence type mapping
+
+### Acceptance criteria
+
+- [ ] Evidence type taxonomy documented
+- [ ] At least 3 rules have `requirement_coverage.expected_evidence` populated
+- [ ] `requirement_kind` populated for rules where human judgment is vs. is not required
+- [ ] Schema validates populated evidence fields
+
+---
+
+## T-3 — STAC / AOI Support Facts (eligibility flags)
+
+### Goal
+
+Define which rules are eligible for STAC satellite support facts. The app uses this to auto-trigger STAC search.
+
+### Contract requirements
+
+- Define STAC eligibility criteria based on rule metadata:
+  - Rules tagged `monitoring` → STAC eligible
+  - Rules with `type: monitoring` → STAC eligible
+  - Rules tagged `satellite` or `remote-sensing` → STAC eligible (add these tags where appropriate)
+  - All other rules → NOT STAC eligible
+- Add explicit `stac_eligible` flag to rule metadata OR document the tag-based heuristic clearly
+- Ensure rules.rich.json tags are complete enough for the app to filter
+
+### Tag taxonomy (add where missing)
+
+- `satellite` — evidence can come from satellite imagery
+- `remote-sensing` — synonym for satellite
+- `monitoring` — requires periodic monitoring evidence
+- `baseline` — baseline scenario determination
+- `emissions` — emissions calculation
+- `leakage` — leakage assessment
+- `calculation` — quantitative calculation
+
+### Files to modify
+
+- `methodologies/UNFCCC/Forestry/AR-ACM0003/v02-0/rules.rich.json` — add tags where missing
+- `docs/ingest/ENCODING_PLAYBOOK.md` — document tag taxonomy and STAC eligibility rules
+
+### Acceptance criteria
+
+- [ ] Tag taxonomy documented
+- [ ] STAC eligibility heuristic documented (tag-based or explicit flag)
+- [ ] AR-ACM0003 rules have appropriate tags for satellite eligibility
+- [ ] App can determine STAC eligibility from rule metadata alone
+
+---
+
+## T-4 — Document and Workbook Support (extraction contracts)
+
+### Goal
+
+Define what structured facts can be extracted from project documents and workbooks. The app uses this for evidence support.
+
+### Contract requirements
+
+- Document baseline/removals/leakage calculation formulas for AR-ACM0003
+- Define workbook column/field expectations for:
+  - Baseline scenario values
+  - Project scenario values
+  - Leakage estimates
+  - Uncertainty ranges
+- Define PDD section extraction targets (which sections map to which rules)
+- Define monitoring report extraction targets
+
+### Files to create/modify
+
+- `docs/examples/baseline-calculation-template.md` — calculation formula documentation
+- `docs/examples/workbook-field-expectations.md` — what the app should expect in workbooks
+- `datasets/param-extraction/` — parameter extraction test fixtures (extend if needed)
+
+### Acceptance criteria
+
+- [ ] Baseline calculation formulas documented for AR-ACM0003
+- [ ] Workbook field expectations defined (column names, units, ranges)
+- [ ] At least one test fixture workbook exists for validation
+- [ ] PDD section → rule mapping documented for AR-ACM0003
+
+---
+
+## T-5 — Exportable Verification Output (schema contracts)
+
+### Goal
+
+Define the schema for verification output. The app generates the document; this repo defines what it must contain.
+
+### Contract requirements
+
+- Define verification snapshot schema:
+  - Project metadata (methodology, version, AOI)
+  - Rule reviews array (id, status, rationale, support_reference, evidence_links, reviewer, timestamp)
+  - Provenance chain (who reviewed, when, app version)
+  - STAC support facts (for eligible rules)
+  - Aggregated summary (% reviewed, % verified, open items)
+- Ensure schema is JSON Schema validatable
+- Document export invariants (what must be true for a valid export)
+
+### Files to create/modify
+
+- `schemas/verification-snapshot.schema.json` (new)
+- `docs/examples/verification-snapshot-example.json` (new)
+- `tests/verification-snapshot-schema.test.js` (new)
+
+### Acceptance criteria
+
+- [ ] Verification snapshot schema defined and valid JSON Schema
+- [ ] Example snapshot passes schema validation
+- [ ] Schema covers all 5 phase deliverables
+- [ ] CI test validates example against schema
+
+---
+
+## What this roadmap excludes
+
+- UI implementation (owned by app repo)
+- API endpoints (owned by app repo)
+- PDF generation (owned by app repo)
+- STAC search implementation (owned by app repo)
+- Project management (owned by app repo)
+- Authentication / access control (owned by app repo)

--- a/docs/roadmaps/traceable-rule-review-mvp/phase-status.json
+++ b/docs/roadmaps/traceable-rule-review-mvp/phase-status.json
@@ -1,0 +1,69 @@
+{
+  "roadmap": "traceable-rule-review-mvp",
+  "repo": "article6-methodologies",
+  "repo_boundary": "Methodology semantics, schema definitions, data quality. Does NOT own UI, workflow, persistence, or export execution.",
+  "goal": "Provide canonical rule contract support so the app can build a traceable rule review workspace.",
+  "last_updated_at": "2026-04-15T00:00:00Z",
+  "status": "active",
+  "current_focus": ["T-1: Rule Review Record (data contract)"],
+  "phases": [
+    {
+      "id": "t-1-rule-review-record",
+      "name": "Rule Review Record (data contract)",
+      "week": 1,
+      "status": "active",
+      "depends_on": []
+    },
+    {
+      "id": "t-2-defensible-verification",
+      "name": "Defensible Verification (evidence contract)",
+      "week": 2,
+      "status": "planned",
+      "depends_on": ["t-1-rule-review-record"]
+    },
+    {
+      "id": "t-3-stac-aoi-support-facts",
+      "name": "STAC / AOI Support Facts (eligibility flags)",
+      "week": 3,
+      "status": "planned",
+      "depends_on": ["t-2-defensible-verification"]
+    },
+    {
+      "id": "t-4-document-workbook-support",
+      "name": "Document and Workbook Support (extraction contracts)",
+      "week": 4,
+      "status": "planned",
+      "depends_on": ["t-3-stac-aoi-support-facts"]
+    },
+    {
+      "id": "t-5-exportable-verification-output",
+      "name": "Exportable Verification Output (schema contracts)",
+      "week": 5,
+      "status": "planned",
+      "depends_on": ["t-4-document-workbook-support"]
+    }
+  ],
+  "pr_evidence": {},
+  "pr_meta": {
+    "T-1": {
+      "title": "Rule Review Record (data contract)",
+      "summary": "Ensure every rule has text, section anchors, type, tags. Minimum data for app review panel."
+    },
+    "T-2": {
+      "title": "Defensible Verification (evidence contract)",
+      "summary": "Define evidence type taxonomy. Populate expected_evidence and requirement_kind per rule."
+    },
+    "T-3": {
+      "title": "STAC / AOI Support Facts (eligibility flags)",
+      "summary": "Define STAC eligibility via tags. Tag taxonomy. Satellite eligibility heuristic."
+    },
+    "T-4": {
+      "title": "Document and Workbook Support (extraction contracts)",
+      "summary": "Document calculation formulas, workbook field expectations, PDD section mappings."
+    },
+    "T-5": {
+      "title": "Exportable Verification Output (schema contracts)",
+      "summary": "Define verification snapshot schema. JSON Schema for export validation."
+    }
+  }
+}


### PR DESCRIPTION
## WHAT

- Add `docs/roadmaps/traceable-rule-review-mvp/ROADMAP.md` — 5-phase roadmap for methodology contract work
- Add `docs/roadmaps/traceable-rule-review-mvp/phase-status.json` — phase tracker with consistent IDs
- Remove old `complete-methodology-coverage` roadmap (replaced)

## WHY

- App needs canonical rule contract support to build the review workspace
- Clean repo boundary: methodologies owns semantics/schemas/data quality; app owns UI/execution
- Same phase IDs (T-1 through T-5) across both repos — no cross-reference confusion
- 5-week path to paid pilots

## Phases

- **T-1** (active): Rule Review Record data contract — text, anchors, type, tags
- **T-2**: Evidence contract — evidence type taxonomy, expected_evidence, requirement_kind
- **T-3**: STAC eligibility flags — tag taxonomy, satellite eligibility heuristic
- **T-4**: Extraction contracts — workbook fields, PDD section mappings, calculation formulas
- **T-5**: Schema contracts — verification snapshot JSON Schema

## Cross-repo

- App roadmap: https://github.com/Fredilly/app.article6/pull/495
