### PR TITLE
docs: traceable-rule-review-mvp SSOT

### DIFF
--- a/docs/roadmaps/complete-methodology-coverage/ROADMAP.md
+++ b/docs/roadmaps/complete-methodology-coverage/ROADMAP.md
@@ -1,0 +1,134 @@
+# Complete Methodology Coverage
+
+Status is sourced from `phase-status.json`.
+
+## Goal
+
+Encode enough methodologies so the app can serve any VVB working with UNFCCC CDM forestry and agriculture methods. The app roadmap (verifiable-review-record) consumes these outputs — this repo supplies the data.
+
+## What's already done
+
+Rich rule schemas (RC-S1 through RC-S7) are locked. AR-ACM0003 v02-0 is encoded with rich rules, sections, and version lineage. Several agriculture methods are ingested. Manifest generation works.
+
+## What's needed
+
+The app's VRR-4 milestone requires at least 2 methodologies loadable (AR-ACM0003 + one agriculture method). VVB pilots will want their specific methodology. Encoding must be fast and repeatable.
+
+## Parallel dependency
+
+This roadmap feeds directly into `app.article6/docs/roadmaps/verifiable-review-record`. VRR-1 (review surface) is app-only. VRR-2+ need methodology data to be complete.
+
+---
+
+## CMC-1 — AR-ACM0003 Completeness (Week 1)
+
+### Goal
+
+Ensure AR-ACM0003 v02-0 has everything the app needs for the review surface.
+
+### Deliverables
+
+- Verify `rules.rich.json` has `text`, `logic`, `refs`, and `tags` for every rule
+- Verify `sections.rich.json` has stable anchors for all sections
+- Verify `META.json` has correct tool references and hashes
+- Fix any gaps found during verification
+- Run all existing AR-ACM0003 tests — must pass green
+
+### Acceptance criteria
+
+- [ ] Every rule in `rules.rich.json` has non-empty `text` field
+- [ ] Section anchors resolve to valid PDF locations
+- [ ] All AR-ACM0003 CI tests pass
+- [ ] Manifest index.json includes AR-ACM0003 v02-0
+
+---
+
+## CMC-2 — One Agriculture Methodology (Week 2)
+
+### Goal
+
+Encode one complete agriculture methodology end-to-end so the app can demonstrate multi-methodology support.
+
+### Deliverables
+
+- Pick the best candidate from existing ingests (ACM0010 or AMS-III.A — whichever is most complete)
+- Encode full `rules.rich.json` with text, logic, refs, tags
+- Encode `sections.rich.json` with stable anchors
+- Generate `META.json` with tool references
+- Run CI — must pass all gates
+
+### Selection criteria
+
+- Most rules (max coverage for demo)
+- Has multiple versions (version lineage support)
+- Already has some ingest data in `batches/`
+
+### Acceptance criteria
+
+- [ ] Selected methodology has `rules.rich.json` with all rules populated
+- [ ] Section anchors valid
+- [ ] CI passes
+- [ ] Manifest index.json includes the methodology
+- [ ] App can load and display it alongside AR-ACM0003
+
+---
+
+## CMC-3 — Encoding Playbook (Week 3)
+
+### Goal
+
+Document the encoding process so new methodologies can be added in <1 day each. VVB pilots will bring their own methods.
+
+### Deliverables
+
+- Step-by-step encoding guide in `docs/ingest/ENCODING_PLAYBOOK.md`
+- Template files for new methodology onboarding
+- Checklist: what to verify before marking a methodology as "app-ready"
+- Example: encode a second methodology using the playbook to validate it
+
+### Acceptance criteria
+
+- [ ] Playbook exists and covers: PDF source → sections → rules → rich → META → manifest
+- [ ] Template files in `templates/` are up to date
+- [ ] A new methodology can be encoded following only the playbook (tested)
+- [ ] "App-ready" checklist has 5+ verification steps
+
+---
+
+## CMC-4 — Batch Encoding for Pilots (Weeks 4-5)
+
+### Goal
+
+Encode the top 3-5 methodologies that VVB pilots are most likely to request.
+
+### Deliverables
+
+- Encode AR-AM0014 (forestry, v02-0) — second forestry method
+- Encode ACM0010 (agriculture, v03-0) — most-used agriculture method
+- Encode one more based on pilot demand
+- All pass CI gates
+- Manifest includes all encoded methodologies
+
+### Acceptance criteria
+
+- [ ] 3+ methodologies fully encoded and app-ready
+- [ ] All CI tests pass
+- [ ] Manifest index.json complete
+- [ ] App can switch between methodologies seamlessly
+
+---
+
+## Always-optimizing
+
+1. **Data quality over quantity** — one perfect methodology beats three incomplete ones
+2. **Stable IDs are sacred** — never change a rule_id or section_id after encoding
+3. **Lean + rich separation** — keep rules.json thin, rules.rich.json rich
+4. **CI gates are the contract** — if CI passes, the app can consume it
+5. **Encoding speed matters** — VVB pilots can't wait 2 weeks for their methodology
+
+## What this roadmap excludes
+
+- New methodology sources (Gold Standard is lower priority than UNFCCC for Article 6)
+- Schema redesign (RC-S1-S7 locked the contract)
+- App UI work (that's the app repo's job)
+- Document extraction (that's app-side VRR-3)

--- a/docs/roadmaps/complete-methodology-coverage/phase-status.json
+++ b/docs/roadmaps/complete-methodology-coverage/phase-status.json
@@ -1,0 +1,56 @@
+{
+  "roadmap": "complete-methodology-coverage",
+  "goal": "Encode enough methodologies so the app can serve any VVB working with UNFCCC CDM forestry and agriculture methods.",
+  "last_updated_at": "2026-04-15T00:00:00Z",
+  "status": "active",
+  "parallel_dependency": "app.article6/docs/roadmaps/verifiable-review-record",
+  "current_focus": ["CMC-1: AR-ACM0003 Completeness"],
+  "phases": [
+    {
+      "id": "cmc-1-ar-acm0003-completeness",
+      "name": "AR-ACM0003 Completeness",
+      "week": 1,
+      "status": "active"
+    },
+    {
+      "id": "cmc-2-one-agriculture-methodology",
+      "name": "One Agriculture Methodology",
+      "week": 2,
+      "status": "planned",
+      "depends_on": ["cmc-1-ar-acm0003-completeness"]
+    },
+    {
+      "id": "cmc-3-encoding-playbook",
+      "name": "Encoding Playbook",
+      "week": 3,
+      "status": "planned",
+      "depends_on": ["cmc-2-one-agriculture-methodology"]
+    },
+    {
+      "id": "cmc-4-batch-encoding-for-pilots",
+      "name": "Batch Encoding for Pilots",
+      "weeks": "4-5",
+      "status": "planned",
+      "depends_on": ["cmc-3-encoding-playbook"]
+    }
+  ],
+  "pr_evidence": {},
+  "pr_meta": {
+    "CMC-1": {
+      "title": "AR-ACM0003 Completeness",
+      "summary": "Verify and fix AR-ACM0003 v02-0 so every rule has text, logic, refs, and valid section anchors."
+    },
+    "CMC-2": {
+      "title": "One Agriculture Methodology",
+      "summary": "Encode one complete agriculture methodology end-to-end for multi-methodology demo."
+    },
+    "CMC-3": {
+      "title": "Encoding Playbook",
+      "summary": "Document the encoding process so new methodologies can be added in <1 day."
+    },
+    "CMC-4": {
+      "title": "Batch Encoding for Pilots",
+      "summary": "Encode top 3-5 methodologies VVB pilots are most likely to request."
+    }
+  }
+}

--- a/docs/roadmaps/traceable-rule-review-mvp/ROADMAP.md
+++ b/docs/roadmaps/traceable-rule-review-mvp/ROADMAP.md
@@ -1,0 +1,94 @@
+# Traceable Rule Review MVP
+
+SSOT: `docs/roadmaps/traceable-rule-review-mvp/phase-status.json`
+
+## Repo boundary
+
+This roadmap owns **methodology semantics, schema definitions, and data quality**. It does NOT own UI, workflow, persistence, or export execution. That is the app repo: [traceable-rule-review-mvp](https://github.com/Fredilly/app.article6/tree/main/docs/roadmaps/traceable-rule-review-mvp).
+
+## Goal
+
+Provide canonical rule contract support so the app can build a traceable rule review workspace. The app consumes what this repo produces — schemas, rule metadata quality, evidence type definitions.
+
+## How existing pieces fit
+
+| Piece | Where it lives | Contract responsibility |
+|-------|---------------|------------------------|
+| Methods | `rules.rich.json` — id, summary, logic, type, refs, tags | Must provide: display text, section anchors, type for STAC eligibility |
+| Complex methods | Version lineage (RC-S5) | Must provide: stable IDs across versions, version relationships |
+| STAC eligibility | Tags exist (`monitoring`, `baseline`) but no explicit flag | Must define: which rules are satellite-eligible |
+| Evidence types | `requirement_coverage.expected_evidence` (RC-S6) | Must populate: structured evidence hints per rule |
+| Manual review flags | `requirement_kind` field exists but sparse | Must populate: human-judgment-required vs. calculable |
+
+## Priority
+
+truthfulness > defensibility > clean repo boundaries > data completeness
+
+## PR body standard
+
+For every PR related to this roadmap:
+
+```
+Roadmap: traceable-rule-review-mvp
+Roadmap-Phase: <phase-id>
+SSOT: docs/roadmaps/traceable-rule-review-mvp/phase-status.json
+```
+
+## Phases
+
+### Phase 1 — Rule Review Record (data contract)
+
+Ensure every rule has minimum data the app needs for a review panel.
+
+- `text` or `summary`: non-empty string for display
+- `refs.section_anchor`: valid anchor linking to methodology PDF
+- `refs.primary_section`: section ID for navigation
+- `type`: one of eligibility, parameter, equation, calc, monitoring, leakage, uncertainty, reporting
+- `tags`: array for filtering (baseline, emissions, etc.)
+- `id` and `stable_id`: both present, consistent
+
+Verify AR-ACM0003 v02-0 `rules.rich.json` and fix gaps.
+
+### Phase 2 — Defensible Verification (evidence contract)
+
+Define evidence types supportable per rule type.
+
+- Evidence type taxonomy: monitoring_report, satellite_imagery, calculation_workbook, project_document, field_measurement, third_party_verification
+- Map rule types → expected evidence types
+- Populate `requirement_coverage.expected_evidence` where grounded
+- Populate `requirement_kind`: human-judgment-required vs. calculable vs. document-check
+
+### Phase 3 — STAC / AOI Support Facts (eligibility flags)
+
+Define which rules are eligible for STAC satellite support.
+
+- STAC eligibility criteria from rule metadata
+- Tag taxonomy: satellite, remote_sensing, monitoring, baseline, emissions, leakage, calculation
+- Rules tagged `monitoring` → STAC eligible
+- Document the heuristic clearly in encoding playbook
+
+### Phase 4 — Document and Workbook Support (extraction contracts)
+
+Define what structured facts can be extracted from documents.
+
+- Baseline/removals/leakage calculation formulas for AR-ACM0003
+- Workbook column/field expectations (names, units, ranges)
+- PDD section → rule mapping
+- Monitoring report extraction targets
+
+### Phase 5 — Exportable Verification Output (schema contracts)
+
+Define the schema for verification output the app generates.
+
+- Verification snapshot schema (JSON Schema)
+- Project metadata, rule reviews array, provenance chain, STAC facts, aggregated summary
+- Example snapshot passes validation
+- CI test for schema compliance
+
+## What this excludes
+
+- UI implementation (owned by app repo)
+- API endpoints (owned by app repo)
+- PDF generation (owned by app repo)
+- STAC search implementation (owned by app repo)
+- Project management (owned by app repo)

--- a/docs/roadmaps/traceable-rule-review-mvp/phase-status.json
+++ b/docs/roadmaps/traceable-rule-review-mvp/phase-status.json
@@ -1,0 +1,41 @@
+{
+  "phase_meta": {
+    "status": "active",
+    "summary": "Provide canonical rule contract support so the app can build a traceable rule review workspace. Owns schemas, data quality, and evidence type definitions.",
+    "current_focus": [
+      "Verify AR-ACM0003 v02-0 rules.rich.json has text, anchors, type, tags for every rule"
+    ],
+    "not_active_now": [
+      "New methodology encoding (after AR-ACM0003 contract is solid)",
+      "Schema redesign (RC-S1-S7 locked the contract)",
+      "App UI work (owned by app repo)"
+    ]
+  },
+  "phase_1_rule_review_record": {
+    "status": "active",
+    "title": "Rule Review Record (data contract)",
+    "summary": "Ensure every rule has text, section anchors, type, tags. Minimum data for app review panel display."
+  },
+  "phase_2_defensible_verification": {
+    "status": "planned",
+    "title": "Defensible Verification (evidence contract)",
+    "summary": "Evidence type taxonomy, expected_evidence population, requirement_kind. Map rule types to supportable evidence."
+  },
+  "phase_3_stac_aoi_support_facts": {
+    "status": "planned",
+    "title": "STAC / AOI Support Facts (eligibility flags)",
+    "summary": "Tag taxonomy for satellite eligibility. STAC eligibility heuristic documented."
+  },
+  "phase_4_document_workbook_support": {
+    "status": "planned",
+    "title": "Document and Workbook Support (extraction contracts)",
+    "summary": "Calculation formulas, workbook field expectations, PDD section mappings."
+  },
+  "phase_5_exportable_verification_output": {
+    "status": "planned",
+    "title": "Exportable Verification Output (schema contracts)",
+    "summary": "Verification snapshot JSON Schema. Example validation. CI test."
+  },
+  "pr_evidence": {},
+  "pr_notes": {}
+}


### PR DESCRIPTION
Roadmap: traceable-rule-review-mvp
Roadmap-Phase: phase-1-rule-review-record
SSOT: docs/roadmaps/traceable-rule-review-mvp/phase-status.json

## WHAT

- Add `docs/roadmaps/traceable-rule-review-mvp/ROADMAP.md` — narrative roadmap
- Add `docs/roadmaps/traceable-rule-review-mvp/phase-status.json` — machine-readable SSOT

## WHY

- Single source of truth for canonical rule contract support
- Consistent phase IDs across methodologies and app repos
- Clean repo boundary: methodologies owns semantics/schemas/data quality
- App roadmap: https://github.com/Fredilly/app.article6/pull/496

## Phases

- Phase 1 (active): Rule Review Record data contract — text, anchors, type, tags
- Phase 2: Evidence contract — evidence type taxonomy, expected_evidence, requirement_kind
- Phase 3: STAC eligibility flags — tag taxonomy, satellite eligibility heuristic
- Phase 4: Extraction contracts — workbook fields, PDD section mappings, calculation formulas
- Phase 5: Schema contracts — verification snapshot JSON Schema
