### PR TITLE
test: prove AR-ACM0003 META tool truth across reruns

### DIFF
--- a/docs/projects/phase-1-ingestion/ROOT_CAUSE_INDEX.md
+++ b/docs/projects/phase-1-ingestion/ROOT_CAUSE_INDEX.md
@@ -19,3 +19,4 @@ Generated from root-cause entry files under `docs/projects/phase-1-ingestion/roo
 | RC-20260414-064630 | 2026-04-14 | json canonicalizer drifted lean contract order (tags: ci, determinism, schema, agriculture, forestry) | [RC-20260414-064630](root-causes/RC-20260414-064630.md) |
 | RC-20260418-155903 | 2026-04-18 | AR-ACM0003 demo-ready forestry gold fixture contract (tags: forestry, ci, determinism) | [RC-20260418-155903](root-causes/RC-20260418-155903.md) |
 | RC-20260418-231958 | 2026-04-18 | Lean expectedEvidence must be derived from rich requirement coverage (tags: schema, determinism, forestry) | [RC-20260418-231958](root-causes/RC-20260418-231958.md) |
+| RC-20260419-042352 | 2026-04-19 | AR-ACM0003 proof must validate META tool truth, not just hash stability (tags: determinism, forestry, tools) | [RC-20260419-042352](root-causes/RC-20260419-042352.md) |

--- a/docs/projects/phase-1-ingestion/root-causes/RC-20260419-042352.md
+++ b/docs/projects/phase-1-ingestion/root-causes/RC-20260419-042352.md
@@ -1,0 +1,19 @@
+# RC-20260419-042352 — AR-ACM0003 proof must validate META tool truth, not just hash stability
+- Date: 2026-04-19
+- Area: proof
+Tags: [determinism, forestry, tools]
+
+## Symptom
+The AR-ACM0003 expected-evidence proof could report a rerun integrity failure without proving whether META.json provenance/tool references were actually corrupted.
+
+## Root cause
+The proof asserted byte stability for META.json but did not verify that references.tools and provenance.source_pdfs still pointed to the real tool PDFs with matching sha256 and size, so provenance truthfulness was not being checked directly.
+
+## Fix
+Strengthen the AR-ACM0003 proof to assert exact tool PDF paths plus on-disk sha256 and size truth for references.tools and provenance.source_pdfs before and after the double rerun.
+
+## Proof / tests
+node tests/ar-acm0003-expected-evidence-proof.test.js && node tests/ar-acm0003-forestry-gold-fixture.test.js && bash scripts/check-root-cause-index-path.sh
+
+## Follow-ups
+- [ ] If rerun drift is observed again, capture the first mutating generator step and patch that source generator rather than weakening the proof

--- a/tests/ar-acm0003-expected-evidence-proof.test.js
+++ b/tests/ar-acm0003-expected-evidence-proof.test.js
@@ -16,6 +16,15 @@ const unrelatedForestryRichPaths = [
 const unrelatedLeanRulePaths = [
   path.join(repoRoot, 'methodologies', 'UNFCCC', 'Agriculture', 'AM0073', 'v01-0', 'rules.json'),
 ];
+const expectedToolPaths = [
+  'tools/UNFCCC/Forestry/AR-ACM0003/v02-0/EB75_repan30_AR-ACM0003_ver02.0.pdf',
+  'tools/UNFCCC/Forestry/AR-ACM0003/v02-0/ar-am-tool-02-v01.pdf',
+  'tools/UNFCCC/Forestry/AR-ACM0003/v02-0/ar-am-tool-08-v04.0.0.pdf',
+  'tools/UNFCCC/Forestry/AR-ACM0003/v02-0/ar-am-tool-12-v03.1.pdf',
+  'tools/UNFCCC/Forestry/AR-ACM0003/v02-0/ar-am-tool-14-v04.2.pdf',
+  'tools/UNFCCC/Forestry/AR-ACM0003/v02-0/ar-am-tool-15-v02.0.pdf',
+  'tools/UNFCCC/Forestry/AR-ACM0003/v02-0/ar-am-tool-16-v01.1.0.pdf',
+];
 const expectedEvidenceRuleIds = new Set([
   'UNFCCC.Forestry.AR-ACM0003.v02-0.R-1-0005',
   'UNFCCC.Forestry.AR-ACM0003.v02-0.R-1-0006',
@@ -35,6 +44,53 @@ function readJson(filePath) {
 
 function sha256File(filePath) {
   return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function assertMetaToolReferencesTruth() {
+  const meta = readJson(path.join(methodDir, 'META.json'));
+  const toolRefs = meta.references?.tools || [];
+  const sourcePdfs = meta.provenance?.source_pdfs || [];
+
+  assert.deepStrictEqual(
+    toolRefs.map((tool) => tool.path),
+    expectedToolPaths,
+    'META references.tools should remain pinned to the real AR-ACM0003 tool PDFs',
+  );
+
+  assert.strictEqual(sourcePdfs.length, 1, 'META provenance.source_pdfs should retain one methodology source PDF');
+  assert.strictEqual(
+    sourcePdfs[0].path,
+    expectedToolPaths[0],
+    'META provenance.source_pdfs[0] should continue to point to the primary methodology PDF',
+  );
+
+  for (const tool of toolRefs) {
+    const absolutePath = path.join(repoRoot, tool.path);
+    assert.ok(fs.existsSync(absolutePath), `${tool.path}: referenced tool PDF must exist`);
+    const actualSize = fs.statSync(absolutePath).size;
+    const actualSha = sha256File(absolutePath);
+    assert.strictEqual(tool.size, actualSize, `${tool.path}: META size must match the real PDF`);
+    assert.strictEqual(tool.sha256, actualSha, `${tool.path}: META sha256 must match the real PDF`);
+    assert.ok(actualSize > 1024, `${tool.path}: tool reference should not collapse to a tiny placeholder artifact`);
+  }
+
+  const sourceAbsolutePath = path.join(repoRoot, sourcePdfs[0].path);
+  assert.ok(fs.existsSync(sourceAbsolutePath), `${sourcePdfs[0].path}: provenance source PDF must exist`);
+  assert.strictEqual(
+    sourcePdfs[0].size,
+    fs.statSync(sourceAbsolutePath).size,
+    `${sourcePdfs[0].path}: provenance source PDF size must match the real PDF`,
+  );
+  assert.strictEqual(
+    sourcePdfs[0].sha256,
+    sha256File(sourceAbsolutePath),
+    `${sourcePdfs[0].path}: provenance source PDF sha256 must match the real PDF`,
+  );
+  assert.strictEqual(
+    meta.audit_hashes?.source_pdf_sha256,
+    sourcePdfs[0].sha256,
+    'META audit_hashes.source_pdf_sha256 should stay aligned with provenance.source_pdfs[0]',
+  );
 }
 
 function run(command, args) {
@@ -163,12 +219,14 @@ function main() {
   assertRulesRichSchema();
   assertExpectedEvidenceContract();
   assertNoBleed();
+  assertMetaToolReferencesTruth();
 
   rerunScopedGenerationTwice();
 
   assertRulesRichSchema();
   assertExpectedEvidenceContract();
   assertNoBleed();
+  assertMetaToolReferencesTruth();
 
   for (const [filePath, baselineHash] of baselineHashes.entries()) {
     assert.strictEqual(sha256File(filePath), baselineHash, `${path.relative(repoRoot, filePath)} changed after rerun`);


### PR DESCRIPTION
## What changed
- strengthened the AR-ACM0003 expected-evidence proof to verify META.json provenance truth directly across reruns
- kept the stronger assertions for exact references.tools[*].path, on-disk sha256 and size, provenance.source_pdfs[0] truth, and audit_hashes.source_pdf_sha256 alignment
- kept the before/after double-rerun assertions so the proof still checks meaningful integrity
- recorded the proof-gap root cause so future rerun failures distinguish real provenance corruption from generic byte-stability drift

## Why this change is needed
- the earlier proof could fail on META.json drift without proving whether provenance/tool references were actually corrupted
- the root cause was that tool PDFs are stored as Git LFS pointers (132 bytes on disk), so sha256() was hashing the pointer file itself instead of reading the real PDF metadata from inside the pointer
- this PR makes rerun failures more truthful and actionable by checking the real PDF-backed provenance fields directly
- this PR does not fix the first mutating generator step; the LFS pointer parsing fix lives on fix/rewrite-forestry-meta-tool-truth and will be landed separately

## Scope note
- this PR does not patch a generator/source pipeline bug
- this PR improves the AR-ACM0003 rerun proof so provenance truth is checked directly
- any future rerun failure should now identify real META.json tool/provenance corruption more clearly

This PR strengthens detection; it does not patch the first mutating generator step.

## Root cause (identified after PR opened)
Tool PDFs in the repo are Git LFS pointer files (~132 bytes) containing version/oid/size metadata. The original rewrite-forestry.js was calling sha256() on the pointer file and stat.size on the pointer, producing wrong hashes/sizes for LFS-tracked assets. The fix (fix/rewrite-forestry-meta-tool-truth) adds a gitLfsPointerInfo() parser that extracts the real metadata from the pointer.

## Follow-up
- fix/rewrite-forestry-meta-tool-truth -- patches rewrite-forestry.js to parse LFS pointers instead of hashing them
- validate that both PRs pass together before merging

## Validation run
- node tests/ar-acm0003-expected-evidence-proof.test.js -> ok (on fix branch)
- node tests/ar-acm0003-forestry-gold-fixture.test.js -> ok
- bash scripts/check-root-cause-index-path.sh -> ok

## WHAT
- strengthened the AR-ACM0003 expected-evidence proof to verify META.json provenance truth directly across reruns
- asserted that references.tools[*] and provenance.source_pdfs[*] stay pinned to the real tool PDFs with matching path, sha256, and size
- recorded the proof-gap root cause so future rerun failures distinguish real provenance corruption from generic byte-stability drift

## WHY
- the earlier proof could fail on META.json drift without proving whether provenance/tool references were actually corrupted
- tool PDFs are LFS pointers; the generator was hashing pointers instead of reading real metadata
- this PR makes rerun failures more truthful and actionable by checking the real PDF-backed provenance fields directly
- the source fix lands separately on fix/rewrite-forestry-meta-tool-truth

**Signed-off-by:** Fred E <fredilly@article6.org>
