### PR TITLE
fix(forestry): preserve truthful tool metadata in rewrite-forestry

### DIFF
--- a/docs/projects/phase-1-ingestion/ROOT_CAUSE_INDEX.md
+++ b/docs/projects/phase-1-ingestion/ROOT_CAUSE_INDEX.md
@@ -20,3 +20,4 @@ Generated from root-cause entry files under `docs/projects/phase-1-ingestion/roo
 | RC-20260418-155903 | 2026-04-18 | AR-ACM0003 demo-ready forestry gold fixture contract (tags: forestry, ci, determinism) | [RC-20260418-155903](root-causes/RC-20260418-155903.md) |
 | RC-20260418-231958 | 2026-04-18 | Lean expectedEvidence must be derived from rich requirement coverage (tags: schema, determinism, forestry) | [RC-20260418-231958](root-causes/RC-20260418-231958.md) |
 | RC-20260419-042352 | 2026-04-19 | AR-ACM0003 proof must validate META tool truth, not just hash stability (tags: determinism, forestry, tools) | [RC-20260419-042352](root-causes/RC-20260419-042352.md) |
+| RC-20260419-053113 | 2026-04-19 | rewrite-forestry must preserve truthful tool metadata for LFS-backed PDFs (tags: determinism, forestry, tools) | [RC-20260419-053113](root-causes/RC-20260419-053113.md) |

--- a/docs/projects/phase-1-ingestion/root-causes/RC-20260419-053113.md
+++ b/docs/projects/phase-1-ingestion/root-causes/RC-20260419-053113.md
@@ -1,0 +1,19 @@
+# RC-20260419-053113 — rewrite-forestry must preserve truthful tool metadata for LFS-backed PDFs
+- Date: 2026-04-19
+- Area: forestry
+Tags: [determinism, forestry, tools]
+
+## Symptom
+rewrite-forestry.js could serialize tiny Git LFS pointer byte counts into META references.tools size/sha256 instead of the underlying PDF metadata, causing second-run AR-ACM0003 tool reference corruption in pointer-backed environments.
+
+## Root cause
+makeToolEntry hashed and sized raw on-disk bytes without recognizing Git LFS pointer files, so metadata collapsed to pointer payload values when a tool checkout was backed by LFS pointers.
+
+## Fix
+Teach rewrite-forestry.js to detect Git LFS pointer files and emit the pointer oid sha256 plus declared size, while preserving normal file hashing for real PDFs. Add a regression covering both pointer-backed digests and the AR-ACM0003 second-run rewrite flow.
+
+## Proof / tests
+node tests/rewrite-forestry-meta-tool-truth.test.js && node tests/ar-acm0003-expected-evidence-proof.test.js
+
+## Follow-ups
+- [ ] If rewrite-forestry rich-rule churn remains relevant for AR-ACM0003, isolate that idempotency issue separately from tool metadata truth

--- a/scripts/rewrite-forestry.js
+++ b/scripts/rewrite-forestry.js
@@ -13,6 +13,29 @@ function sha256(filePath) {
   return crypto.createHash('sha256').update(data).digest('hex');
 }
 
+function gitLfsPointerInfo(filePath) {
+  const data = fs.readFileSync(filePath, 'utf8');
+  const lines = data.split(/\r?\n/);
+  if (lines[0] !== 'version https://git-lfs.github.com/spec/v1') return null;
+  const oidLine = lines.find((line) => line.startsWith('oid sha256:'));
+  const sizeLine = lines.find((line) => line.startsWith('size '));
+  if (!oidLine || !sizeLine) return null;
+  const oid = oidLine.slice('oid sha256:'.length).trim();
+  const size = Number.parseInt(sizeLine.slice('size '.length).trim(), 10);
+  if (!/^[a-f0-9]{64}$/.test(oid) || !Number.isFinite(size) || size < 0) return null;
+  return { sha256: oid, size };
+}
+
+function fileDigest(filePath) {
+  const pointer = gitLfsPointerInfo(filePath);
+  if (pointer) return pointer;
+  const stat = fs.statSync(filePath);
+  return {
+    sha256: sha256(filePath),
+    size: stat.size
+  };
+}
+
 function sortKeysDeep(value) {
   if (Array.isArray(value)) return value.map(sortKeysDeep);
   if (value && typeof value === 'object') {
@@ -717,7 +740,7 @@ function makeLeanRule(index, spec) {
 
 function makeToolEntry(filePath) {
   const absPath = path.join(ROOT, filePath);
-  const stat = fs.statSync(absPath);
+  const digest = fileDigest(absPath);
   const kind = filePath.split('.').pop();
  const doc = (() => {
    const parts = filePath.split('/');
@@ -740,43 +763,56 @@ function makeToolEntry(filePath) {
   return sortKeysDeep({
     doc,
     path: filePath,
-    sha256: sha256(absPath),
-    size: stat.size,
+    sha256: digest.sha256,
+    size: digest.size,
     kind,
     url: null
   });
 }
 
-const requestedMethodKeys = process.argv.slice(2).map(normalizeMethodKey).filter(Boolean);
-const selectedMethods = requestedMethodKeys.length > 0
-  ? Object.entries(METHODS).filter(([methodKey]) => requestedMethodKeys.includes(methodKey))
-  : Object.entries(METHODS);
+function main(argv = process.argv.slice(2)) {
+  const requestedMethodKeys = argv.map(normalizeMethodKey).filter(Boolean);
+  const selectedMethods = requestedMethodKeys.length > 0
+    ? Object.entries(METHODS).filter(([methodKey]) => requestedMethodKeys.includes(methodKey))
+    : Object.entries(METHODS);
 
-for (const requestedMethodKey of requestedMethodKeys) {
-  if (!METHODS[requestedMethodKey]) {
-    console.warn(`Skipping ${requestedMethodKey} (method not configured)`);
-  }
-}
-
-for (const [methodKey, config] of selectedMethods) {
-  const methodDir = path.join(METHODOLOGY_ROOT, methodKey);
-  if (!fs.existsSync(methodDir)) {
-    console.warn(`Skipping ${methodKey} (directory missing)`);
-    continue;
+  for (const requestedMethodKey of requestedMethodKeys) {
+    if (!METHODS[requestedMethodKey]) {
+      console.warn(`Skipping ${requestedMethodKey} (method not configured)`);
+    }
   }
 
-  const richRules = config.rules.map((rule, idx) => makeRichRule(methodKey, idx, rule));
-  const leanRules = config.rules.map((rule, idx) => makeLeanRule(idx, rule));
+  for (const [methodKey, config] of selectedMethods) {
+    const methodDir = path.join(METHODOLOGY_ROOT, methodKey);
+    if (!fs.existsSync(methodDir)) {
+      console.warn(`Skipping ${methodKey} (directory missing)`);
+      continue;
+    }
 
-  writeJSON(path.join(methodDir, 'rules.rich.json'), richRules);
-  writeJSON(path.join(methodDir, 'rules.json'), { rules: leanRules });
+    const richRules = config.rules.map((rule, idx) => makeRichRule(methodKey, idx, rule));
+    const leanRules = config.rules.map((rule, idx) => makeLeanRule(idx, rule));
 
-  const metaPath = path.join(methodDir, 'META.json');
-  const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
-  const toolEntries = config.tools.map(makeToolEntry);
-  meta.references = meta.references || {};
-  meta.references.tools = sortKeysDeep(toolEntries);
-  writeJSON(metaPath, meta);
+    writeJSON(path.join(methodDir, 'rules.rich.json'), richRules);
+    writeJSON(path.join(methodDir, 'rules.json'), { rules: leanRules });
+
+    const metaPath = path.join(methodDir, 'META.json');
+    const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+    const toolEntries = config.tools.map(makeToolEntry);
+    meta.references = meta.references || {};
+    meta.references.tools = sortKeysDeep(toolEntries);
+    writeJSON(metaPath, meta);
+  }
+
+  console.log(`OK: rewrote forestry rules and META references for ${selectedMethods.length} method(s).`);
 }
 
-console.log(`OK: rewrote forestry rules and META references for ${selectedMethods.length} method(s).`);
+module.exports = {
+  fileDigest,
+  gitLfsPointerInfo,
+  main,
+  makeToolEntry
+};
+
+if (require.main === module) {
+  main();
+}

--- a/tests/rewrite-forestry-meta-tool-truth.test.js
+++ b/tests/rewrite-forestry-meta-tool-truth.test.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const { fileDigest, makeToolEntry } = require('../scripts/rewrite-forestry.js');
+
+function readHeadFile(relPath) {
+  return execFileSync('git', ['show', `HEAD:${relPath}`], { cwd: repoRoot });
+}
+
+function sha256Buffer(buffer) {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+function main() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rewrite-forestry-lfs-'));
+  const methodDir = path.join(repoRoot, 'methodologies', 'UNFCCC', 'Forestry', 'AR-ACM0003', 'v02-0');
+  const trackedFiles = new Map([
+    ['META.json', readHeadFile('methodologies/UNFCCC/Forestry/AR-ACM0003/v02-0/META.json')],
+    ['rules.rich.json', readHeadFile('methodologies/UNFCCC/Forestry/AR-ACM0003/v02-0/rules.rich.json')],
+    ['rules.json', readHeadFile('methodologies/UNFCCC/Forestry/AR-ACM0003/v02-0/rules.json')],
+    ['sections.json', readHeadFile('methodologies/UNFCCC/Forestry/AR-ACM0003/v02-0/sections.json')],
+  ]);
+  try {
+    const lfsOid = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    const lfsSize = 987654;
+    const pointerPath = path.join(tempDir, 'pointer.pdf');
+    fs.writeFileSync(
+      pointerPath,
+      `version https://git-lfs.github.com/spec/v1\noid sha256:${lfsOid}\nsize ${lfsSize}\n`,
+      'utf8',
+    );
+
+    assert.deepStrictEqual(
+      fileDigest(pointerPath),
+      { sha256: lfsOid, size: lfsSize },
+      'fileDigest should preserve Git LFS pointer oid/size instead of hashing the pointer payload',
+    );
+
+    const realToolRelPath = 'tools/UNFCCC/Forestry/AR-ACM0003/v02-0/ar-am-tool-02-v01.pdf';
+    const realToolAbsPath = path.join(repoRoot, realToolRelPath);
+    const realBytes = fs.readFileSync(realToolAbsPath);
+    const realEntry = makeToolEntry(realToolRelPath);
+
+    assert.equal(realEntry.path, realToolRelPath);
+    assert.equal(realEntry.size, realBytes.length, 'real tool entry should retain the on-disk PDF size');
+    assert.equal(realEntry.sha256, sha256Buffer(realBytes), 'real tool entry should retain the on-disk PDF sha256');
+
+    const relMethodDir = path.relative(repoRoot, methodDir);
+    execFileSync(process.execPath, ['scripts/rewrite-forestry.js', relMethodDir], { cwd: repoRoot, stdio: 'inherit' });
+    execFileSync(process.execPath, ['scripts/enrich-methodology-outputs.js', relMethodDir], { cwd: repoRoot, stdio: 'inherit' });
+    execFileSync(process.execPath, ['scripts/derive-lean-from-rich.js', relMethodDir], { cwd: repoRoot, stdio: 'inherit' });
+    execFileSync(process.execPath, ['scripts/rewrite-forestry.js', relMethodDir], { cwd: repoRoot, stdio: 'inherit' });
+
+    const meta = JSON.parse(fs.readFileSync(path.join(methodDir, 'META.json'), 'utf8'));
+    for (const tool of meta.references.tools || []) {
+      const absolutePath = path.join(repoRoot, tool.path);
+      const digest = fileDigest(absolutePath);
+      assert.equal(tool.sha256, digest.sha256, `${tool.path}: rewritten META sha256 should stay truthful on second run`);
+      assert.equal(tool.size, digest.size, `${tool.path}: rewritten META size should stay truthful on second run`);
+    }
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    for (const [name, contents] of trackedFiles) {
+      fs.writeFileSync(path.join(methodDir, name), contents);
+    }
+  }
+
+  console.log('ok');
+}
+
+main();


### PR DESCRIPTION
## What changed
- fixed `scripts/rewrite-forestry.js` so `META.references.tools[*]` keeps truthful `sha256` and `size` metadata when a tool file is present as a Git LFS pointer instead of a fully materialized PDF
- refactored `rewrite-forestry.js` into a `main()` entrypoint so its metadata helpers can be tested directly without CLI side effects
- added a focused regression test for both pointer-backed tool metadata and the AR-ACM0003 second-run rewrite flow
- recorded the root cause in the ingestion ledger and regenerated the index

## Why this change is needed
- `rewrite-forestry.js` was hashing and sizing raw on-disk bytes without recognizing Git LFS pointer files
- in pointer-backed environments, that could collapse `META.references.tools[*]` to tiny pointer payload metadata instead of the underlying PDF metadata
- AR-ACM0003 tool references must remain truthful across reruns: same real `path`, `sha256`, and `size`, with no second-run provenance corruption

## Scope
- source fix only for `rewrite-forestry.js` tool metadata generation
- no changes to the rich-to-lean `expectedEvidence` design
- no unrelated methodology rewrites or app changes

## Validation run
- `node tests/rewrite-forestry-meta-tool-truth.test.js` -> `ok`
- `node tests/ar-acm0003-expected-evidence-proof.test.js` -> `ok`
- `bash scripts/check-root-cause-index-path.sh` -> `[root-cause:index-path] ok`

## Notes
- the new regression covers the exact reported failure mode: when a tool file is a Git LFS pointer, the emitted tool metadata must use the pointer `oid sha256` and declared object `size`, not the pointer file payload bytes
- the AR-ACM0003 proof remains green after the source fix

**Signed-off-by:** Fred E <fredilly@article6.org>