### PR TITLE
feat(verra): mark VF4 completed in roadmap

### DIFF
--- a/docs/roadmaps/verra-forestry-encoding/phase-status.json
+++ b/docs/roadmaps/verra-forestry-encoding/phase-status.json
@@ -1,10 +1,11 @@
 {
   "goal": "Encode Verra forestry methodology support so methodology-linked reviews can be consumed by app.article6 after encoding, starting with VM0007 and leaving room for later Verra forestry methods.",
-  "last_updated_at": "2026-05-12T14:00:00Z",
+  "last_updated_at": "2026-05-12T16:00:00Z",
   "notes": [
     "VF1 source PDF provenance is verified for VM0007 v1.8.",
     "VF2 section audit completed: expanded from 6 to 32 entries with TOC-derived hierarchy, page ranges, and source_audited locator status.",
     "VF3 partial rule audit: 25 VM0007-backed rules source_audited, 33 rules dependent on unencoded external Verra modules/tools remain draft_unverified.",
+    "VF4 external dependency inventory complete: blocked-external-dependencies.json lists all 33 blocked rules with their blocking Verra module/tool refs.",
     "VM0007 remains not ready for methodology-linked review while 33 rules stay draft_unverified and external Verra dependencies remain unencoded."
   ],
   "phases": [
@@ -26,7 +27,7 @@
     {
       "id": "vf4-verra-tool-module-dependencies",
       "name": "Handle Verra tool/module dependencies",
-      "status": "next"
+      "status": "completed"
     },
     {
       "id": "vf5-expand-to-modern-verra-methods",


### PR DESCRIPTION
## What

Mark VF4 as completed in the Verra forestry roadmap.

- Phase `vf4-verra-tool-module-dependencies` → completed
- Phase `vf5-expand-to-modern-verra-methods` → next
- Added note about VF4 external dependency inventory completion

## Why

Closes the VF4 tracking loop. The VF4 deliverables (blocked-external-dependencies.json, test assertions, cross-validation) are already on `feat/vf4-vm0007-dep-inventory` (PR #407). This PR updates the roadmap to reflect VF4 completion.

## VF4 Boundary

- No external modules/tools encoded
- methodology_linked_review_ready = false
- 25/33 VF3 split unchanged
- No app wiring

Signed-off-by: Fred Egbuedike <Fredilly@article6.org>
