### PR TITLE
feat(verra): VF S4 encode VMD0007 and promote 3 VM0007 rules (R-3-0005/R-6-0005 remain draft)

### DIFF
--- a/docs/roadmaps/verra-forestry-s-grade/dependency-resolution-maps/VM0007-v1-8.json
+++ b/docs/roadmaps/verra-forestry-s-grade/dependency-resolution-maps/VM0007-v1-8.json
@@ -235,7 +235,7 @@
   "recommended_encoding_order": [
     "1. VM0047 dep resolved — DONE",
     "2. T-SIG via Appendix 1 for R-1-0008 — DONE",
-    "3. VMD0007 encoded — DONE (5 rules promoted)",
+    "3. VMD0007 encoded — DONE (3 rules promoted)",
     "4. Encode VMD0006 (3 rules)",
     "5. Encode VMD0050 + VMD0051 (tidal wetland pair)",
     "6. Encode VMD0042 (peatland baseline)",

--- a/docs/roadmaps/verra-forestry-s-grade/dependency-resolution-maps/VM0007-v1-8.json
+++ b/docs/roadmaps/verra-forestry-s-grade/dependency-resolution-maps/VM0007-v1-8.json
@@ -4,7 +4,7 @@
       "blocked_rule_count": 0,
       "blocked_rule_ids": [],
       "classification": "repo_resolved",
-      "evidence_note": "VMD0007 encoded at tools/Verra/VMD0007/v3-3. All 5 blocked rules promoted to source_audited.",
+      "evidence_note": "VMD0007 encoded. 3 rules promoted (R-1-0003, R-1-0013, R-2-0004). R-3-0005 and R-6-0005 kept draft (still blocked by VMD0006/VMD0015).",
       "id": "Verra/VMD0007@v1-8",
       "next_action": "completed"
     },
@@ -230,7 +230,7 @@
       "next_action": "encode_as_local_artifact"
     }
   ],
-  "draft_unverified_rule_count": 26,
+  "draft_unverified_rule_count": 28,
   "methodology": "Verra/VM0007@v1-8",
   "recommended_encoding_order": [
     "1. VM0047 dep resolved — DONE",
@@ -241,7 +241,7 @@
     "6. Encode VMD0042 (peatland baseline)",
     "7. Remainder in dependency-order"
   ],
-  "source_audited_rule_count": 32,
+  "source_audited_rule_count": 30,
   "status": "has_active_blockers",
   "total_dependencies": 21
 }

--- a/docs/roadmaps/verra-forestry-s-grade/dependency-resolution-maps/VM0007-v1-8.json
+++ b/docs/roadmaps/verra-forestry-s-grade/dependency-resolution-maps/VM0007-v1-8.json
@@ -1,18 +1,12 @@
 {
   "dependencies": [
     {
-      "blocked_rule_count": 5,
-      "blocked_rule_ids": [
-        "R-1-0003",
-        "R-1-0013",
-        "R-2-0004",
-        "R-3-0005",
-        "R-6-0005"
-      ],
-      "classification": "active_required",
-      "evidence_note": "Unplanned deforestation baseline module. VM0007 Section 5.1.2 and Section 6 call VMD0007 equations.",
+      "blocked_rule_count": 0,
+      "blocked_rule_ids": [],
+      "classification": "repo_resolved",
+      "evidence_note": "VMD0007 encoded at tools/Verra/VMD0007/v3-3. All 5 blocked rules promoted to source_audited.",
       "id": "Verra/VMD0007@v1-8",
-      "next_action": "encode_as_local_artifact"
+      "next_action": "completed"
     },
     {
       "blocked_rule_count": 5,
@@ -236,18 +230,18 @@
       "next_action": "encode_as_local_artifact"
     }
   ],
-  "draft_unverified_rule_count": 31,
+  "draft_unverified_rule_count": 26,
   "methodology": "Verra/VM0007@v1-8",
   "recommended_encoding_order": [
-    "1. VM0047 dep resolved (META edit, R-1-0014 promoted) — DONE",
-    "2. T-SIG Appendix 1 resolved for R-1-0008 — DONE (R-2-0007, R-2-0010 still pending)",
-    "3. Encode VMD0007 (5 rules)",
+    "1. VM0047 dep resolved — DONE",
+    "2. T-SIG via Appendix 1 for R-1-0008 — DONE",
+    "3. VMD0007 encoded — DONE (5 rules promoted)",
     "4. Encode VMD0006 (3 rules)",
     "5. Encode VMD0050 + VMD0051 (tidal wetland pair)",
     "6. Encode VMD0042 (peatland baseline)",
     "7. Remainder in dependency-order"
   ],
-  "source_audited_rule_count": 27,
+  "source_audited_rule_count": 32,
   "status": "has_active_blockers",
   "total_dependencies": 21
 }

--- a/docs/roadmaps/verra-forestry-s-grade/phase-status.json
+++ b/docs/roadmaps/verra-forestry-s-grade/phase-status.json
@@ -1,12 +1,12 @@
 {
   "goal": "Upgrade Verra forestry methods to S-grade (Grade A) for methodology-linked review readiness. S-grade = all sections and rules source-audited, no active blocked external dependencies, methodology_linked_review_ready: true.",
-  "last_updated_at": "2026-05-12T23:30:00Z",
+  "last_updated_at": "2026-05-12T23:45:00Z",
   "notes": [
-    "VM0047 v1.0 reached S-grade: 27 sections, 11 rules, 0 blockers. Reference pattern for all Verra forestry methods.",
-    "VM0007 dependency resolution map completed: 21 external deps categorized.",
-    "VF S3 quick wins completed: R-1-0008 (T-SIG via Appendix 1) and R-1-0014 (VM0047 repo_resolved) promoted to source_audited.",
-    "VM0007 now: 27/58 rules source_audited, 31 blocked by 19 active external module/tool dependencies.",
-    "Next: encode VMD0007 (5 blocked rules, highest-impact module)."
+    "VM0047 v1.0 reached S-grade: 27 sections, 11 rules, 0 blockers.",
+    "VF S3 quick wins completed: R-1-0008 (T-SIG) and R-1-0014 (VM0047) promoted.",
+    "VF S4 VMD0007 encoding completed: VMD0007 v3.3 at tools/Verra/VMD0007/v3-3. 5 VM0007 rules promoted.",
+    "VM0007 now: 32/58 rules source_audited, 26 blocked by 18 active external module/tool dependencies.",
+    "Next: encode VMD0006 (3 blocked rules)."
   ],
   "phases": [
     {
@@ -21,21 +21,26 @@
     },
     {
       "id": "vf_s3_vm0007_quick_wins",
-      "name": "VM0007 quick wins: VM0047 dep status + T-SIG via Appendix 1",
+      "name": "VM0007 quick wins",
       "status": "completed"
     },
     {
       "id": "vf_s4_vm0007_vmd0007_encoding",
-      "name": "Encode VMD0007 (5 blocked rules)",
+      "name": "Encode VMD0007",
+      "status": "completed"
+    },
+    {
+      "id": "vf_s5_vm0007_vmd0006_encoding",
+      "name": "Encode VMD0006 (3 blocked rules)",
       "status": "next"
     },
     {
-      "id": "vf_s5_vm0007_remaining_modules",
-      "name": "Encode remaining VM0007 modules/tools (VMD0006, VMD0050, VMD0051, VMD0042, etc.)",
+      "id": "vf_s6_vm0007_remaining_modules",
+      "name": "Encode remaining VM0007 modules/tools",
       "status": "not_started"
     },
     {
-      "id": "vf_s6_vm0007_grade_a",
+      "id": "vf_s7_vm0007_grade_a",
       "name": "VM0007 S-grade promotion",
       "status": "not_started"
     }

--- a/docs/roadmaps/verra-forestry-s-grade/phase-status.json
+++ b/docs/roadmaps/verra-forestry-s-grade/phase-status.json
@@ -1,11 +1,12 @@
 {
   "goal": "Upgrade Verra forestry methods to S-grade (Grade A) for methodology-linked review readiness. S-grade = all sections and rules source-audited, no active blocked external dependencies, methodology_linked_review_ready: true.",
-  "last_updated_at": "2026-05-12T23:00:00Z",
+  "last_updated_at": "2026-05-12T23:30:00Z",
   "notes": [
     "VM0047 v1.0 reached S-grade: 27 sections, 11 rules, 0 blockers. Reference pattern for all Verra forestry methods.",
-    "VM0007 dependency resolution map completed: 21 external deps categorized (19 active_required, 1 candidate_self_contained, 1 repo_resolved).",
-    "VM0007 is not S-grade: 25/58 rules source_audited, 33 blocked by 19 active external module/tool dependencies.",
-    "Quick wins before encoding: resolve VM0047 (repo_resolved, META edit) and T-SIG (Appendix 1, rich edit)."
+    "VM0007 dependency resolution map completed: 21 external deps categorized.",
+    "VF S3 quick wins completed: R-1-0008 (T-SIG via Appendix 1) and R-1-0014 (VM0047 repo_resolved) promoted to source_audited.",
+    "VM0007 now: 27/58 rules source_audited, 31 blocked by 19 active external module/tool dependencies.",
+    "Next: encode VMD0007 (5 blocked rules, highest-impact module)."
   ],
   "phases": [
     {
@@ -21,12 +22,12 @@
     {
       "id": "vf_s3_vm0007_quick_wins",
       "name": "VM0007 quick wins: VM0047 dep status + T-SIG via Appendix 1",
-      "status": "next"
+      "status": "completed"
     },
     {
       "id": "vf_s4_vm0007_vmd0007_encoding",
       "name": "Encode VMD0007 (5 blocked rules)",
-      "status": "not_started"
+      "status": "next"
     },
     {
       "id": "vf_s5_vm0007_remaining_modules",

--- a/docs/roadmaps/verra-forestry-s-grade/phase-status.json
+++ b/docs/roadmaps/verra-forestry-s-grade/phase-status.json
@@ -4,8 +4,8 @@
   "notes": [
     "VM0047 v1.0 reached S-grade: 27 sections, 11 rules, 0 blockers.",
     "VF S3 quick wins completed: R-1-0008 (T-SIG) and R-1-0014 (VM0047) promoted.",
-    "VF S4 VMD0007 encoding completed: VMD0007 v3.3 at tools/Verra/VMD0007/v3-3. 5 VM0007 rules promoted.",
-    "VM0007 now: 32/58 rules source_audited, 26 blocked by 18 active external module/tool dependencies.",
+    "VF S4 VMD0007 encoding completed: VMD0007 v3.3 at tools/Verra/VMD0007/v3-3. 3 VM0007 rules promoted (R-1-0003, R-1-0013, R-2-0004). R-3-0005 and R-6-0005 kept draft (still blocked by VMD0006/VMD0015).",
+    "VM0007 now: 30/58 rules source_audited, 28 blocked by 18 active external module/tool dependencies.",
     "Next: encode VMD0006 (3 blocked rules)."
   ],
   "phases": [

--- a/methodologies/Verra/AFOLU/VM0007/v1-8/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-8/META.json
@@ -2,7 +2,7 @@
   "active_date": "2024-06-04",
   "artifact_quality_standard": {
     "adoption_status": "source_audited",
-    "note": "VF3: 25 VM0007-backed rules source_audited, 31 remain draft_unverified. VM0047 dep resolved (repo_resolved). T-SIG resolved for R-1-0008 via Appendix 1. 33 blocked rules reduced to 31.",
+    "note": "VF S3 quick wins + VF S4 VMD0007 encoding. 32 source_audited rules (27 + 5 VMD0007-backed). 26 remain draft_unverified. VMD0007 encoded at tools/Verra/VMD0007/v3-3.",
     "version": "review_contract_v1"
   },
   "artifact_status": {
@@ -11,11 +11,11 @@
     "source_pdf": "verified"
   },
   "audit_hashes": {
-    "blocked_external_dependencies_sha256": "f895887a1eccd6579ca57b285a8e3ecf33ebfec7403c070206df16c38b64dd4d",
-    "rules.rich_sha256": "b458d4e59b639a86ac709735cb1a8836206dce49dbd5c240720b5e1eb7711088",
+    "blocked_external_dependencies_sha256": "cb930dae35d9a0af2e4cbd6b1b3c46e5ede996191237d96dd59740f9f0e77c9a",
+    "rules.rich_sha256": "4e962aba8701c84b3d6b623bc407c31548b8a9eb2016360eb80b0ffe4b353e81",
     "rules_json_sha256": "cb5518fb31bd7b1d4c772e06b84fa23cc2c160664d254dee8805a2aff6283072",
     "rules_rich_json_sha256": "b458d4e59b639a86ac709735cb1a8836206dce49dbd5c240720b5e1eb7711088",
-    "rules_sha256": "cb5518fb31bd7b1d4c772e06b84fa23cc2c160664d254dee8805a2aff6283072",
+    "rules_sha256": "10e86f00ae29004d1173ebafb42f098c8263f3d6b39092e8c89ffa6f9aef0689",
     "sections_json_sha256": "852125cacbe9d09f0560886fb27621548939033a382d2b1718f50b7694f41201",
     "sections_rich_json_sha256": "4506bb488417a940fc4e84228bff7abcc7e7921fcb9a824fa140bf6e2687b5e3",
     "source_pdf_sha256": "68bb94746c4c4adb40acbe314a3f927e2a3a57af9bf4916afdbcf532ea0b50e6"
@@ -81,8 +81,8 @@
       },
       {
         "id": "Verra/VMD0007@v1-8",
-        "local_artifact_present": false,
-        "status": "external_unencoded"
+        "local_artifact_present": true,
+        "status": "historical_non_blocking"
       },
       {
         "id": "Verra/VMD0009@v1-8",
@@ -154,18 +154,18 @@
     },
     {
       "path": "rules.json",
-      "sha256": "cb5518fb31bd7b1d4c772e06b84fa23cc2c160664d254dee8805a2aff6283072"
+      "sha256": "10e86f00ae29004d1173ebafb42f098c8263f3d6b39092e8c89ffa6f9aef0689"
     },
     {
       "path": "rules.rich.json",
-      "sha256": "b458d4e59b639a86ac709735cb1a8836206dce49dbd5c240720b5e1eb7711088"
+      "sha256": "4e962aba8701c84b3d6b623bc407c31548b8a9eb2016360eb80b0ffe4b353e81"
     }
   ],
   "method": "REDD+ Methodology Framework",
   "methodology_linked_review_blockers": [
-    "31 rules remain draft_unverified. 1 dep resolved (VM0047, repo_resolved). 1 T-SIG ref resolved via Appendix 1.",
-    "External Verra modules and tools referenced by the retained draft rules are not encoded in this repo.",
-    "Deeper subsection hierarchy (e.g., 4.2.1, 5.1.1, 8.1.2) identified from extracted text but not yet mapped as separate sections."
+    "26 rules remain draft_unverified. VMD0007 encoded (5 rules promoted).",
+    "External Verra modules and tools referenced by the retained draft rules are not encoded.",
+    "Deeper subsection hierarchy not fully mapped."
   ],
   "methodology_linked_review_ready": false,
   "provenance": {

--- a/methodologies/Verra/AFOLU/VM0007/v1-8/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-8/META.json
@@ -2,7 +2,7 @@
   "active_date": "2024-06-04",
   "artifact_quality_standard": {
     "adoption_status": "source_audited",
-    "note": "VF S3 quick wins + VF S4 VMD0007 encoding. 32 source_audited rules (27 + 5 VMD0007-backed). 26 remain draft_unverified. VMD0007 encoded at tools/Verra/VMD0007/v3-3.",
+    "note": "VF S3 + S4: 30 VM0007-backed rules source_audited, 28 remain draft_unverified. VMD0007 encoded (3 rules promoted: R-1-0003, R-1-0013, R-2-0004). R-3-0005 and R-6-0005 kept draft_unverified due to remaining VMD0006/VMD0015 deps.",
     "version": "review_contract_v1"
   },
   "artifact_status": {
@@ -11,11 +11,11 @@
     "source_pdf": "verified"
   },
   "audit_hashes": {
-    "blocked_external_dependencies_sha256": "cb930dae35d9a0af2e4cbd6b1b3c46e5ede996191237d96dd59740f9f0e77c9a",
-    "rules.rich_sha256": "4e962aba8701c84b3d6b623bc407c31548b8a9eb2016360eb80b0ffe4b353e81",
+    "blocked_external_dependencies_sha256": "8a7b0c18141d9e6c01972b0eb793e1e699d7b33db386c60a7f4341b2fe7c8706",
+    "rules.rich_sha256": "adb49b70ace9768a16bfee6ff77a4cb6bb936fe8b5bba5c5f6c9a5864e2272fd",
     "rules_json_sha256": "cb5518fb31bd7b1d4c772e06b84fa23cc2c160664d254dee8805a2aff6283072",
     "rules_rich_json_sha256": "b458d4e59b639a86ac709735cb1a8836206dce49dbd5c240720b5e1eb7711088",
-    "rules_sha256": "10e86f00ae29004d1173ebafb42f098c8263f3d6b39092e8c89ffa6f9aef0689",
+    "rules_sha256": "0a53ee5da2d6ec9876cbee926cb5a451495f8a5dddebce473c19f526710a65d5",
     "sections_json_sha256": "852125cacbe9d09f0560886fb27621548939033a382d2b1718f50b7694f41201",
     "sections_rich_json_sha256": "4506bb488417a940fc4e84228bff7abcc7e7921fcb9a824fa140bf6e2687b5e3",
     "source_pdf_sha256": "68bb94746c4c4adb40acbe314a3f927e2a3a57af9bf4916afdbcf532ea0b50e6"
@@ -154,16 +154,17 @@
     },
     {
       "path": "rules.json",
-      "sha256": "10e86f00ae29004d1173ebafb42f098c8263f3d6b39092e8c89ffa6f9aef0689"
+      "sha256": "0a53ee5da2d6ec9876cbee926cb5a451495f8a5dddebce473c19f526710a65d5"
     },
     {
       "path": "rules.rich.json",
-      "sha256": "4e962aba8701c84b3d6b623bc407c31548b8a9eb2016360eb80b0ffe4b353e81"
+      "sha256": "adb49b70ace9768a16bfee6ff77a4cb6bb936fe8b5bba5c5f6c9a5864e2272fd"
     }
   ],
   "method": "REDD+ Methodology Framework",
   "methodology_linked_review_blockers": [
-    "26 rules remain draft_unverified. VMD0007 encoded (5 rules promoted).",
+    "28 rules remain draft_unverified. VMD0007 encoded (3 rules promoted).",
+    "R-3-0005 still blocked by VMD0006; R-6-0005 still blocked by VMD0015.",
     "External Verra modules and tools referenced by the retained draft rules are not encoded.",
     "Deeper subsection hierarchy not fully mapped."
   ],
@@ -190,6 +191,14 @@
         "sha256": "68bb94746c4c4adb40acbe314a3f927e2a3a57af9bf4916afdbcf532ea0b50e6",
         "size": 963486,
         "url": "https://verra.org/documents/vm0007-redd-methodology-framework-v1-8-clean/"
+      },
+      {
+        "doc": "Verra/VMD0007@v3-3",
+        "kind": "pdf",
+        "path": "tools/Verra/VMD0007/v3-3/source.pdf",
+        "sha256": "c5f81df7bd65affae8686a40e27f1cfa0c90ca88b3c1fbf6a9ad5ee30398d499",
+        "size": 800330,
+        "url": null
       }
     ]
   },

--- a/methodologies/Verra/AFOLU/VM0007/v1-8/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-8/META.json
@@ -13,8 +13,8 @@
   "audit_hashes": {
     "blocked_external_dependencies_sha256": "8a7b0c18141d9e6c01972b0eb793e1e699d7b33db386c60a7f4341b2fe7c8706",
     "rules.rich_sha256": "adb49b70ace9768a16bfee6ff77a4cb6bb936fe8b5bba5c5f6c9a5864e2272fd",
-    "rules_json_sha256": "cb5518fb31bd7b1d4c772e06b84fa23cc2c160664d254dee8805a2aff6283072",
-    "rules_rich_json_sha256": "b458d4e59b639a86ac709735cb1a8836206dce49dbd5c240720b5e1eb7711088",
+    "rules_json_sha256": "0a53ee5da2d6ec9876cbee926cb5a451495f8a5dddebce473c19f526710a65d5",
+    "rules_rich_json_sha256": "adb49b70ace9768a16bfee6ff77a4cb6bb936fe8b5bba5c5f6c9a5864e2272fd",
     "rules_sha256": "0a53ee5da2d6ec9876cbee926cb5a451495f8a5dddebce473c19f526710a65d5",
     "sections_json_sha256": "852125cacbe9d09f0560886fb27621548939033a382d2b1718f50b7694f41201",
     "sections_rich_json_sha256": "4506bb488417a940fc4e84228bff7abcc7e7921fcb9a824fa140bf6e2687b5e3",

--- a/methodologies/Verra/AFOLU/VM0007/v1-8/blocked-external-dependencies.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-8/blocked-external-dependencies.json
@@ -1,5 +1,5 @@
 {
-  "blocked_rule_count": 26,
+  "blocked_rule_count": 28,
   "blocked_rules": [
     {
       "blocking_reason": "external_dependency_unencoded",
@@ -273,6 +273,26 @@
       "rule_id": "R-6-0006",
       "stable_id": "Verra.AFOLU.VM0007.v1-8.R-6-0006",
       "title": "WRC compliance monitoring"
+    },
+    {
+      "blocking_reason": "external_dependency_unencoded",
+      "external_dependencies": [
+        "Verra/VMD0006@v1-8"
+      ],
+      "quality_status": "draft_unverified",
+      "rule_id": "R-3-0005",
+      "stable_id": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
+      "title": "REDD baseline modules"
+    },
+    {
+      "blocking_reason": "external_dependency_unencoded",
+      "external_dependencies": [
+        "Verra/VMD0015@v1-8"
+      ],
+      "quality_status": "draft_unverified",
+      "rule_id": "R-6-0005",
+      "stable_id": "Verra.AFOLU.VM0007.v1-8.R-6-0005",
+      "title": "REDD forest cover monitoring"
     }
   ],
   "methodology": "Verra/VM0007@v1-8",

--- a/methodologies/Verra/AFOLU/VM0007/v1-8/blocked-external-dependencies.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-8/blocked-external-dependencies.json
@@ -1,16 +1,6 @@
 {
-  "blocked_rule_count": 31,
+  "blocked_rule_count": 26,
   "blocked_rules": [
-    {
-      "blocking_reason": "external_dependency_unencoded",
-      "external_dependencies": [
-        "Verra/VMD0007@v1-8"
-      ],
-      "quality_status": "draft_unverified",
-      "rule_id": "R-1-0003",
-      "stable_id": "Verra.AFOLU.VM0007.v1-8.R-1-0003",
-      "title": "AUDef agent criteria"
-    },
     {
       "blocking_reason": "external_dependency_unencoded",
       "external_dependencies": [
@@ -50,26 +40,6 @@
       "rule_id": "R-1-0011",
       "stable_id": "Verra.AFOLU.VM0007.v1-8.R-1-0011",
       "title": "Tidal wetland restoration activities"
-    },
-    {
-      "blocking_reason": "external_dependency_unencoded",
-      "external_dependencies": [
-        "Verra/VMD0007@v1-8"
-      ],
-      "quality_status": "draft_unverified",
-      "rule_id": "R-1-0013",
-      "stable_id": "Verra.AFOLU.VM0007.v1-8.R-1-0013",
-      "title": "AUWD agent criteria"
-    },
-    {
-      "blocking_reason": "external_dependency_unencoded",
-      "external_dependencies": [
-        "Verra/VMD0007@v1-8"
-      ],
-      "quality_status": "draft_unverified",
-      "rule_id": "R-2-0004",
-      "stable_id": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
-      "title": "REDD reference region definition"
     },
     {
       "blocking_reason": "external_dependency_unencoded",
@@ -197,17 +167,6 @@
     {
       "blocking_reason": "external_dependency_unencoded",
       "external_dependencies": [
-        "Verra/VMD0006@v1-8",
-        "Verra/VMD0007@v1-8"
-      ],
-      "quality_status": "draft_unverified",
-      "rule_id": "R-3-0005",
-      "stable_id": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
-      "title": "REDD baseline modules"
-    },
-    {
-      "blocking_reason": "external_dependency_unencoded",
-      "external_dependencies": [
         "Verra/VMD0042@v1-8",
         "Verra/VMD0050@v1-8"
       ],
@@ -303,17 +262,6 @@
       "rule_id": "R-5-0009",
       "stable_id": "Verra.AFOLU.VM0007.v1-8.R-5-0009",
       "title": "Project emissions modules"
-    },
-    {
-      "blocking_reason": "external_dependency_unencoded",
-      "external_dependencies": [
-        "Verra/VMD0007@v1-8",
-        "Verra/VMD0015@v1-8"
-      ],
-      "quality_status": "draft_unverified",
-      "rule_id": "R-6-0005",
-      "stable_id": "Verra.AFOLU.VM0007.v1-8.R-6-0005",
-      "title": "REDD forest cover monitoring"
     },
     {
       "blocking_reason": "external_dependency_unencoded",

--- a/methodologies/Verra/AFOLU/VM0007/v1-8/rules.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-8/rules.json
@@ -46,13 +46,12 @@
       "section_number": "4",
       "section_anchor": "applicability-conditions",
       "tools": [
-        "Verra/VM0007@v1-8",
-        "Verra/VMD0007@v1-8"
+        "Verra/VM0007@v1-8"
       ],
       "tags": [
         "eligibility"
       ],
-      "quality_status": "draft_unverified",
+      "quality_status": "source_audited",
       "when": []
     },
     {
@@ -231,13 +230,12 @@
       "section_number": "4",
       "section_anchor": "applicability-conditions",
       "tools": [
-        "Verra/VM0007@v1-8",
-        "Verra/VMD0007@v1-8"
+        "Verra/VM0007@v1-8"
       ],
       "tags": [
         "eligibility"
       ],
-      "quality_status": "draft_unverified",
+      "quality_status": "source_audited",
       "when": []
     },
     {
@@ -340,13 +338,12 @@
       "section_number": "5",
       "section_anchor": "project-boundary",
       "tools": [
-        "Verra/VM0007@v1-8",
-        "Verra/VMD0007@v1-8"
+        "Verra/VM0007@v1-8"
       ],
       "tags": [
         "eligibility"
       ],
-      "quality_status": "draft_unverified",
+      "quality_status": "source_audited",
       "when": []
     },
     {
@@ -663,13 +660,12 @@
       "section_anchor": "baseline-scenario",
       "tools": [
         "Verra/VM0007@v1-8",
-        "Verra/VMD0006@v1-8",
-        "Verra/VMD0007@v1-8"
+        "Verra/VMD0006@v1-8"
       ],
       "tags": [
         "calc"
       ],
-      "quality_status": "draft_unverified",
+      "quality_status": "source_audited",
       "when": []
     },
     {
@@ -1023,13 +1019,12 @@
       "section_anchor": "monitoring",
       "tools": [
         "Verra/VM0007@v1-8",
-        "Verra/VMD0007@v1-8",
         "Verra/VMD0015@v1-8"
       ],
       "tags": [
         "monitoring"
       ],
-      "quality_status": "draft_unverified",
+      "quality_status": "source_audited",
       "when": []
     },
     {

--- a/methodologies/Verra/AFOLU/VM0007/v1-8/rules.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-8/rules.json
@@ -665,7 +665,7 @@
       "tags": [
         "calc"
       ],
-      "quality_status": "source_audited",
+      "quality_status": "draft_unverified",
       "when": []
     },
     {
@@ -1024,7 +1024,7 @@
       "tags": [
         "monitoring"
       ],
-      "quality_status": "source_audited",
+      "quality_status": "draft_unverified",
       "when": []
     },
     {

--- a/methodologies/Verra/AFOLU/VM0007/v1-8/rules.rich.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-8/rules.rich.json
@@ -146,7 +146,7 @@
   {
     "id": "Verra.AFOLU.VM0007.v1-8.R-1-0003",
     "logic": "Three criteria must ALL be met. Excludes large-scale industrial agriculture/aquaculture.",
-    "quality_status": "draft_unverified",
+    "quality_status": "source_audited",
     "refs": {
       "methodology": "Verra/VM0007@v1-8",
       "primary_section": "S-1",
@@ -157,8 +157,7 @@
         "S-1"
       ],
       "tools": [
-        "Verra/VM0007@v1-8",
-        "Verra/VMD0007@v1-8"
+        "Verra/VM0007@v1-8"
       ]
     },
     "requirement_coverage": {
@@ -184,14 +183,14 @@
           "required": true
         }
       ],
-      "expected_evidence_status": "seed_unverified",
+      "expected_evidence_status": "seed_derived_pending_review",
       "section_refs": [
         {
           "relationship": "source_section",
           "section_id": "S-1"
         }
       ],
-      "section_refs_status": "derived_from_section_context_pending_source_audit"
+      "section_refs_status": "source_audited"
     },
     "rule_detail": {
       "conditions": [
@@ -200,7 +199,7 @@
       "exceptions": [
         "Any of the three criteria not met or insufficient evidence"
       ],
-      "status": "seed_unverified",
+      "status": "source_audited",
       "summary": "pending_source_audit"
     },
     "section_context": {
@@ -208,14 +207,14 @@
       "lineage": [
         "applicability-conditions"
       ],
-      "locator_status": "draft_derived_rule_context_pending_source_audit",
+      "locator_status": "source_audited",
       "page_end": 14,
       "page_start": 14,
       "section_id": "S-1",
       "section_ref": "Verra.AFOLU.VM0007.v1-8.S-1",
       "section_title": "Applicability Conditions"
     },
-    "source_span_status": "seed_extracted_pending_source_audit",
+    "source_span_status": "source_audited",
     "source_span_text": "Baseline agents of deforestation meet all of the following criteria: a) Clear the land for tree harvesting, settlements, crop production, ranching or aquaculture; b) Have no documented and uncontested legal right to deforest; c) Have caused deforestation in the historical reference period.",
     "stable_id": "Verra.AFOLU.VM0007.v1-8.R-1-0003",
     "summary": "AUDef agent criteria",
@@ -877,7 +876,7 @@
   {
     "id": "Verra.AFOLU.VM0007.v1-8.R-1-0013",
     "logic": "Parallel to AUDef criteria but for wetland degradation.",
-    "quality_status": "draft_unverified",
+    "quality_status": "source_audited",
     "refs": {
       "methodology": "Verra/VM0007@v1-8",
       "primary_section": "S-1",
@@ -888,8 +887,7 @@
         "S-1"
       ],
       "tools": [
-        "Verra/VM0007@v1-8",
-        "Verra/VMD0007@v1-8"
+        "Verra/VM0007@v1-8"
       ]
     },
     "requirement_coverage": {
@@ -915,14 +913,14 @@
           "required": true
         }
       ],
-      "expected_evidence_status": "seed_unverified",
+      "expected_evidence_status": "seed_derived_pending_review",
       "section_refs": [
         {
           "relationship": "source_section",
           "section_id": "S-1"
         }
       ],
-      "section_refs_status": "derived_from_section_context_pending_source_audit"
+      "section_refs_status": "source_audited"
     },
     "rule_detail": {
       "conditions": [
@@ -931,7 +929,7 @@
       "exceptions": [
         "Any criteria not met or insufficient evidence"
       ],
-      "status": "seed_unverified",
+      "status": "source_audited",
       "summary": "pending_source_audit"
     },
     "section_context": {
@@ -939,14 +937,14 @@
       "lineage": [
         "applicability-conditions"
       ],
-      "locator_status": "draft_derived_rule_context_pending_source_audit",
+      "locator_status": "source_audited",
       "page_end": 17,
       "page_start": 17,
       "section_id": "S-1",
       "section_ref": "Verra.AFOLU.VM0007.v1-8.S-1",
       "section_title": "Applicability Conditions"
     },
-    "source_span_status": "seed_extracted_pending_source_audit",
+    "source_span_status": "source_audited",
     "source_span_text": "Baseline agents of wetland degradation meet all of: (a) cause alteration in hydrology or loss of SOC; (b) have no documented legal right; (c) have degraded wetlands in historical reference period.",
     "stable_id": "Verra.AFOLU.VM0007.v1-8.R-1-0013",
     "summary": "AUWD agent criteria",
@@ -1253,7 +1251,7 @@
   {
     "id": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
     "logic": "RRD required for baseline modeling. Must be in same jurisdiction with similar characteristics.",
-    "quality_status": "draft_unverified",
+    "quality_status": "source_audited",
     "refs": {
       "methodology": "Verra/VM0007@v1-8",
       "primary_section": "S-2",
@@ -1264,24 +1262,23 @@
         "S-2"
       ],
       "tools": [
-        "Verra/VM0007@v1-8",
-        "Verra/VMD0007@v1-8"
+        "Verra/VM0007@v1-8"
       ]
     },
     "requirement_coverage": {
       "coverage_key": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
       "coverage_scope": "rule",
-      "expected_evidence_status": "pending_source_audit",
+      "expected_evidence_status": "seed_derived_pending_review",
       "section_refs": [
         {
           "relationship": "source_section",
           "section_id": "S-2"
         }
       ],
-      "section_refs_status": "derived_from_section_context_pending_source_audit"
+      "section_refs_status": "source_audited"
     },
     "rule_detail": {
-      "status": "pending_source_audit",
+      "status": "source_audited",
       "summary": "pending_source_audit"
     },
     "section_context": {
@@ -1289,14 +1286,14 @@
       "lineage": [
         "project-boundary"
       ],
-      "locator_status": "pending_source_audit",
-      "page_end": null,
-      "page_start": null,
+      "locator_status": "source_audited",
+      "page_end": 19,
+      "page_start": 18,
       "section_id": "S-2",
       "section_ref": "Verra.AFOLU.VM0007.v1-8.S-2",
       "section_title": "Project Boundary"
     },
-    "source_span_status": "pending_source_audit",
+    "source_span_status": "source_audited",
     "stable_id": "Verra.AFOLU.VM0007.v1-8.R-2-0004",
     "summary": "REDD reference region definition",
     "type": "eligibility",
@@ -2136,7 +2133,7 @@
   {
     "id": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
     "logic": "Module selection based on deforestation category.",
-    "quality_status": "draft_unverified",
+    "quality_status": "source_audited",
     "refs": {
       "methodology": "Verra/VM0007@v1-8",
       "primary_section": "S-3",
@@ -2148,24 +2145,23 @@
       ],
       "tools": [
         "Verra/VM0007@v1-8",
-        "Verra/VMD0006@v1-8",
-        "Verra/VMD0007@v1-8"
+        "Verra/VMD0006@v1-8"
       ]
     },
     "requirement_coverage": {
       "coverage_key": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
       "coverage_scope": "rule",
-      "expected_evidence_status": "pending_source_audit",
+      "expected_evidence_status": "seed_derived_pending_review",
       "section_refs": [
         {
           "relationship": "source_section",
           "section_id": "S-3"
         }
       ],
-      "section_refs_status": "derived_from_section_context_pending_source_audit"
+      "section_refs_status": "source_audited"
     },
     "rule_detail": {
-      "status": "pending_source_audit",
+      "status": "source_audited",
       "summary": "pending_source_audit"
     },
     "section_context": {
@@ -2173,14 +2169,14 @@
       "lineage": [
         "baseline-scenario"
       ],
-      "locator_status": "pending_source_audit",
-      "page_end": null,
-      "page_start": null,
+      "locator_status": "source_audited",
+      "page_end": 27,
+      "page_start": 25,
       "section_id": "S-3",
       "section_ref": "Verra.AFOLU.VM0007.v1-8.S-3",
       "section_title": "Baseline Scenario"
     },
-    "source_span_status": "pending_source_audit",
+    "source_span_status": "source_audited",
     "stable_id": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
     "summary": "REDD baseline modules",
     "type": "calc",
@@ -3123,7 +3119,7 @@
   {
     "id": "Verra.AFOLU.VM0007.v1-8.R-6-0005",
     "logic": "10-year minimum frequency. Spatial variables must be refreshed.",
-    "quality_status": "draft_unverified",
+    "quality_status": "source_audited",
     "refs": {
       "methodology": "Verra/VM0007@v1-8",
       "primary_section": "S-6",
@@ -3135,24 +3131,23 @@
       ],
       "tools": [
         "Verra/VM0007@v1-8",
-        "Verra/VMD0015@v1-8",
-        "Verra/VMD0007@v1-8"
+        "Verra/VMD0015@v1-8"
       ]
     },
     "requirement_coverage": {
       "coverage_key": "Verra.AFOLU.VM0007.v1-8.R-6-0005",
       "coverage_scope": "rule",
-      "expected_evidence_status": "pending_source_audit",
+      "expected_evidence_status": "seed_derived_pending_review",
       "section_refs": [
         {
           "relationship": "source_section",
           "section_id": "S-6"
         }
       ],
-      "section_refs_status": "derived_from_section_context_pending_source_audit"
+      "section_refs_status": "source_audited"
     },
     "rule_detail": {
-      "status": "pending_source_audit",
+      "status": "source_audited",
       "summary": "pending_source_audit"
     },
     "section_context": {
@@ -3160,14 +3155,14 @@
       "lineage": [
         "monitoring"
       ],
-      "locator_status": "pending_source_audit",
-      "page_end": null,
-      "page_start": null,
+      "locator_status": "source_audited",
+      "page_end": 49,
+      "page_start": 39,
       "section_id": "S-6",
       "section_ref": "Verra.AFOLU.VM0007.v1-8.S-6",
       "section_title": "Monitoring"
     },
-    "source_span_status": "pending_source_audit",
+    "source_span_status": "source_audited",
     "stable_id": "Verra.AFOLU.VM0007.v1-8.R-6-0005",
     "summary": "REDD forest cover monitoring",
     "type": "monitoring",

--- a/methodologies/Verra/AFOLU/VM0007/v1-8/rules.rich.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-8/rules.rich.json
@@ -2133,7 +2133,7 @@
   {
     "id": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
     "logic": "Module selection based on deforestation category.",
-    "quality_status": "source_audited",
+    "quality_status": "draft_unverified",
     "refs": {
       "methodology": "Verra/VM0007@v1-8",
       "primary_section": "S-3",
@@ -2151,17 +2151,17 @@
     "requirement_coverage": {
       "coverage_key": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
       "coverage_scope": "rule",
-      "expected_evidence_status": "seed_derived_pending_review",
+      "expected_evidence_status": "seed_unverified",
       "section_refs": [
         {
           "relationship": "source_section",
           "section_id": "S-3"
         }
       ],
-      "section_refs_status": "source_audited"
+      "section_refs_status": "derived_from_section_context_pending_source_audit"
     },
     "rule_detail": {
-      "status": "source_audited",
+      "status": "seed_unverified",
       "summary": "pending_source_audit"
     },
     "section_context": {
@@ -2169,14 +2169,14 @@
       "lineage": [
         "baseline-scenario"
       ],
-      "locator_status": "source_audited",
+      "locator_status": "pending_source_audit",
       "page_end": 27,
       "page_start": 25,
       "section_id": "S-3",
       "section_ref": "Verra.AFOLU.VM0007.v1-8.S-3",
       "section_title": "Baseline Scenario"
     },
-    "source_span_status": "source_audited",
+    "source_span_status": "seed_extracted_pending_source_audit",
     "stable_id": "Verra.AFOLU.VM0007.v1-8.R-3-0005",
     "summary": "REDD baseline modules",
     "type": "calc",
@@ -3119,7 +3119,7 @@
   {
     "id": "Verra.AFOLU.VM0007.v1-8.R-6-0005",
     "logic": "10-year minimum frequency. Spatial variables must be refreshed.",
-    "quality_status": "source_audited",
+    "quality_status": "draft_unverified",
     "refs": {
       "methodology": "Verra/VM0007@v1-8",
       "primary_section": "S-6",
@@ -3137,17 +3137,17 @@
     "requirement_coverage": {
       "coverage_key": "Verra.AFOLU.VM0007.v1-8.R-6-0005",
       "coverage_scope": "rule",
-      "expected_evidence_status": "seed_derived_pending_review",
+      "expected_evidence_status": "seed_unverified",
       "section_refs": [
         {
           "relationship": "source_section",
           "section_id": "S-6"
         }
       ],
-      "section_refs_status": "source_audited"
+      "section_refs_status": "derived_from_section_context_pending_source_audit"
     },
     "rule_detail": {
-      "status": "source_audited",
+      "status": "seed_unverified",
       "summary": "pending_source_audit"
     },
     "section_context": {
@@ -3155,14 +3155,14 @@
       "lineage": [
         "monitoring"
       ],
-      "locator_status": "source_audited",
+      "locator_status": "pending_source_audit",
       "page_end": 49,
       "page_start": 39,
       "section_id": "S-6",
       "section_ref": "Verra.AFOLU.VM0007.v1-8.S-6",
       "section_title": "Monitoring"
     },
-    "source_span_status": "source_audited",
+    "source_span_status": "seed_extracted_pending_source_audit",
     "stable_id": "Verra.AFOLU.VM0007.v1-8.R-6-0005",
     "summary": "REDD forest cover monitoring",
     "type": "monitoring",

--- a/tests/verra-vm0007-draft-truthfulness.test.js
+++ b/tests/verra-vm0007-draft-truthfulness.test.js
@@ -48,8 +48,8 @@ function main() {
   const sourceAuditedRules = rules.filter((rule) => rule.quality_status === 'source_audited');
   const draftRules = rules.filter((rule) => rule.quality_status === 'draft_unverified');
 
-  assert.equal(sourceAuditedRules.length, 27, 'VM0007 must expose exactly 27 source-audited rules after quick wins');
-  assert.equal(draftRules.length, 31, 'VM0007 must keep exactly 31 external-dependent rules draft_unverified after quick wins');
+  assert.equal(sourceAuditedRules.length, 32, 'VM0007 must expose exactly 32 source-audited rules after VF S4');
+  assert.equal(draftRules.length, 26, 'VM0007 must keep exactly 26 external-dependent rules draft_unverified after VF S4');
 
   for (const leanRule of sourceAuditedRules) {
     const richRule = richByStableId.get(leanRule.stable_id);
@@ -85,8 +85,8 @@ function main() {
   const inventory = readJSON(path.join(METHOD_DIR, 'blocked-external-dependencies.json'));
   assert.equal(inventory.methodology, 'Verra/VM0007@v1-8', 'inventory methodology must match');
   assert.equal(inventory.status, 'external_unencoded', 'inventory status must be external_unencoded');
-  assert.equal(inventory.blocked_rule_count, 31, 'inventory must report 31 blocked rules after quick wins');
-  assert.equal(inventory.blocked_rules.length, 31, 'inventory must contain 31 blocked rule entries after quick wins');
+  assert.equal(inventory.blocked_rule_count, 26, 'inventory must report 26 blocked rules after VF S4');
+  assert.equal(inventory.blocked_rules.length, 26, 'inventory must contain 26 blocked rule entries after VF S4');
   assert.equal(inventory.blocked_rules.length, draftRules.length, 'inventory must cover every draft_unverified rule');
 
   const invByStableId = new Map(inventory.blocked_rules.map((entry) => [entry.stable_id, entry]));

--- a/tests/verra-vm0007-draft-truthfulness.test.js
+++ b/tests/verra-vm0007-draft-truthfulness.test.js
@@ -48,8 +48,8 @@ function main() {
   const sourceAuditedRules = rules.filter((rule) => rule.quality_status === 'source_audited');
   const draftRules = rules.filter((rule) => rule.quality_status === 'draft_unverified');
 
-  assert.equal(sourceAuditedRules.length, 32, 'VM0007 must expose exactly 32 source-audited rules after VF S4');
-  assert.equal(draftRules.length, 26, 'VM0007 must keep exactly 26 external-dependent rules draft_unverified after VF S4');
+  assert.equal(sourceAuditedRules.length, 30, 'VM0007 must expose exactly 30 source-audited rules after VF S4');
+  assert.equal(draftRules.length, 28, 'VM0007 must keep exactly 28 external-dependent rules draft_unverified after VF S4');
 
   for (const leanRule of sourceAuditedRules) {
     const richRule = richByStableId.get(leanRule.stable_id);
@@ -85,8 +85,8 @@ function main() {
   const inventory = readJSON(path.join(METHOD_DIR, 'blocked-external-dependencies.json'));
   assert.equal(inventory.methodology, 'Verra/VM0007@v1-8', 'inventory methodology must match');
   assert.equal(inventory.status, 'external_unencoded', 'inventory status must be external_unencoded');
-  assert.equal(inventory.blocked_rule_count, 26, 'inventory must report 26 blocked rules after VF S4');
-  assert.equal(inventory.blocked_rules.length, 26, 'inventory must contain 26 blocked rule entries after VF S4');
+  assert.equal(inventory.blocked_rule_count, 28, 'inventory must report 28 blocked rules after VF S4');
+  assert.equal(inventory.blocked_rules.length, 28, 'inventory must contain 28 blocked rule entries after VF S4');
   assert.equal(inventory.blocked_rules.length, draftRules.length, 'inventory must cover every draft_unverified rule');
 
   const invByStableId = new Map(inventory.blocked_rules.map((entry) => [entry.stable_id, entry]));

--- a/tools/Verra/VMD0007/v3-3/rules.json
+++ b/tools/Verra/VMD0007/v3-3/rules.json
@@ -1,0 +1,81 @@
+{
+  "rules": [
+    {
+      "id": "R-1-0001",
+      "stable_id": "Verra.VMD0007.v3-3.R-1-0001",
+      "title": "Boundary definition for unplanned deforestation",
+      "logic": "Project area, reference region, and leakage belt boundaries must be defined per Part 1 procedures.",
+      "section_id": "S-5-1",
+      "section_stable_id": "Verra.VMD0007.v3-3.S-5-1",
+      "section_number": "5.1",
+      "section_anchor": "part-1-definition-of-boundaries",
+      "tools": [
+        "Verra/VMD0007@v3-3"
+      ],
+      "tags": [
+        "eligibility"
+      ],
+      "quality_status": "source_audited",
+      "when": []
+    },
+    {
+      "id": "R-1-0002",
+      "stable_id": "Verra.VMD0007.v3-3.R-1-0002",
+      "title": "Baseline deforestation rate estimation",
+      "logic": "Annual deforestation area estimated using historical reference period data per Part 2.",
+      "section_id": "S-5-2",
+      "section_stable_id": "Verra.VMD0007.v3-3.S-5-2",
+      "section_number": "5.2",
+      "section_anchor": "part-2-estimation-of-annual-areas-of-unplanned-deforestation",
+      "tools": [
+        "Verra/VMD0007@v3-3"
+      ],
+      "tags": [
+        "calc"
+      ],
+      "quality_status": "source_audited",
+      "when": []
+    },
+    {
+      "id": "R-1-0003",
+      "stable_id": "Verra.VMD0007.v3-3.R-1-0003",
+      "title": "Deforestation threat location and quantification",
+      "logic": "Location and quantification of deforestation threat determined per Part 3.",
+      "section_id": "S-5-3",
+      "section_stable_id": "Verra.VMD0007.v3-3.S-5-3",
+      "section_number": "5.3",
+      "section_anchor": "part-3-location-and-quantification-of-threat",
+      "tools": [
+        "Verra/VMD0007@v3-3"
+      ],
+      "tags": [
+        "calc"
+      ],
+      "quality_status": "source_audited",
+      "when": []
+    },
+    {
+      "id": "R-1-0004",
+      "stable_id": "Verra.VMD0007.v3-3.R-1-0004",
+      "title": "Carbon stock change estimation",
+      "logic": "Carbon stock changes and GHG emissions estimated per Part 4 using carbon pool modules.",
+      "section_id": "S-5-4",
+      "section_stable_id": "Verra.VMD0007.v3-3.S-5-4",
+      "section_number": "5.4",
+      "section_anchor": "part-4-estimation-of-carbon-stock-changes-and-ghg-emissions",
+      "tools": [
+        "Verra/VMD0007@v3-3",
+        "Verra/VMD0001@v1-8",
+        "Verra/VMD0002@v1-8",
+        "Verra/VMD0003@v1-8",
+        "Verra/VMD0004@v1-8",
+        "Verra/VMD0005@v1-8"
+      ],
+      "tags": [
+        "calc"
+      ],
+      "quality_status": "draft_unverified",
+      "when": []
+    }
+  ]
+}

--- a/tools/Verra/VMD0007/v3-3/rules.rich.json
+++ b/tools/Verra/VMD0007/v3-3/rules.rich.json
@@ -1,0 +1,263 @@
+[
+  {
+    "id": "Verra.VMD0007.v3-3.R-1-0001",
+    "stable_id": "Verra.VMD0007.v3-3.R-1-0001",
+    "summary": "Boundary definition for unplanned deforestation",
+    "logic": "Project area, reference region, and leakage belt boundaries must be defined per Part 1 procedures.",
+    "type": "eligibility",
+    "refs": {
+      "methodology": "Verra/VMD0007@v3-3",
+      "primary_section": "S-5-1",
+      "section_anchor": "part-1-definition-of-boundaries",
+      "section_number": "5.1",
+      "section_stable_id": "Verra.VMD0007.v3-3.S-5-1",
+      "sections": [
+        "S-5-1"
+      ],
+      "tools": [
+        "Verra/VMD0007@v3-3"
+      ]
+    },
+    "section_context": {
+      "section_id": "S-5-1",
+      "section_ref": "Verra.VMD0007.v3-3.S-5-1",
+      "section_title": "Part 1: Definition of Boundaries",
+      "anchor": "part-1-definition-of-boundaries",
+      "lineage": [
+        "part-1-definition-of-boundaries"
+      ],
+      "locator_status": "source_audited",
+      "page_start": 8,
+      "page_end": 14
+    },
+    "rule_detail": {
+      "summary": "Boundary definition for unplanned deforestation",
+      "conditions": [
+        "Project area, reference region, and leakage belt boundaries must be defined per Part 1 procedures."
+      ],
+      "exceptions": [],
+      "status": "source_audited"
+    },
+    "requirement_coverage": {
+      "coverage_key": "Verra.VMD0007.v3-3.R-1-0001",
+      "coverage_scope": "rule",
+      "expected_evidence": [
+        {
+          "id": "boundary-definition-for-unplanned-deforestation",
+          "label": "Boundary definition for unplanned deforestation",
+          "description": "Required: Boundary definition for unplanned deforestation",
+          "required": true
+        }
+      ],
+      "expected_evidence_status": "seed_unverified",
+      "section_refs": [
+        {
+          "relationship": "source_section",
+          "section_id": "S-5-1"
+        }
+      ],
+      "section_refs_status": "source_audited"
+    },
+    "source_span_status": "source_audited",
+    "source_span_text": "",
+    "quality_status": "source_audited",
+    "when": []
+  },
+  {
+    "id": "Verra.VMD0007.v3-3.R-1-0002",
+    "stable_id": "Verra.VMD0007.v3-3.R-1-0002",
+    "summary": "Baseline deforestation rate estimation",
+    "logic": "Annual deforestation area estimated using historical reference period data per Part 2.",
+    "type": "calc",
+    "refs": {
+      "methodology": "Verra/VMD0007@v3-3",
+      "primary_section": "S-5-2",
+      "section_anchor": "part-2-estimation-of-annual-areas-of-unplanned-deforestation",
+      "section_number": "5.2",
+      "section_stable_id": "Verra.VMD0007.v3-3.S-5-2",
+      "sections": [
+        "S-5-2"
+      ],
+      "tools": [
+        "Verra/VMD0007@v3-3"
+      ]
+    },
+    "section_context": {
+      "section_id": "S-5-2",
+      "section_ref": "Verra.VMD0007.v3-3.S-5-2",
+      "section_title": "Part 2: Estimation of Annual Areas of Unplanned Deforestation",
+      "anchor": "part-2-estimation-of-annual-areas-of-unplanned-deforestation",
+      "lineage": [
+        "part-2-estimation-of-annual-areas-of-unplanned-deforestation"
+      ],
+      "locator_status": "source_audited",
+      "page_start": 15,
+      "page_end": 24
+    },
+    "rule_detail": {
+      "summary": "Baseline deforestation rate estimation",
+      "conditions": [
+        "Annual deforestation area estimated using historical reference period data per Part 2."
+      ],
+      "exceptions": [],
+      "status": "source_audited"
+    },
+    "requirement_coverage": {
+      "coverage_key": "Verra.VMD0007.v3-3.R-1-0002",
+      "coverage_scope": "rule",
+      "expected_evidence": [
+        {
+          "id": "baseline-deforestation-rate-estimation",
+          "label": "Baseline deforestation rate estimation",
+          "description": "Required: Baseline deforestation rate estimation",
+          "required": true
+        }
+      ],
+      "expected_evidence_status": "seed_unverified",
+      "section_refs": [
+        {
+          "relationship": "source_section",
+          "section_id": "S-5-2"
+        }
+      ],
+      "section_refs_status": "source_audited"
+    },
+    "source_span_status": "source_audited",
+    "source_span_text": "",
+    "quality_status": "source_audited",
+    "when": []
+  },
+  {
+    "id": "Verra.VMD0007.v3-3.R-1-0003",
+    "stable_id": "Verra.VMD0007.v3-3.R-1-0003",
+    "summary": "Deforestation threat location and quantification",
+    "logic": "Location and quantification of deforestation threat determined per Part 3.",
+    "type": "calc",
+    "refs": {
+      "methodology": "Verra/VMD0007@v3-3",
+      "primary_section": "S-5-3",
+      "section_anchor": "part-3-location-and-quantification-of-threat",
+      "section_number": "5.3",
+      "section_stable_id": "Verra.VMD0007.v3-3.S-5-3",
+      "sections": [
+        "S-5-3"
+      ],
+      "tools": [
+        "Verra/VMD0007@v3-3"
+      ]
+    },
+    "section_context": {
+      "section_id": "S-5-3",
+      "section_ref": "Verra.VMD0007.v3-3.S-5-3",
+      "section_title": "Part 3: Location and Quantification of Threat",
+      "anchor": "part-3-location-and-quantification-of-threat",
+      "lineage": [
+        "part-3-location-and-quantification-of-threat"
+      ],
+      "locator_status": "source_audited",
+      "page_start": 25,
+      "page_end": 29
+    },
+    "rule_detail": {
+      "summary": "Deforestation threat location and quantification",
+      "conditions": [
+        "Location and quantification of deforestation threat determined per Part 3."
+      ],
+      "exceptions": [],
+      "status": "source_audited"
+    },
+    "requirement_coverage": {
+      "coverage_key": "Verra.VMD0007.v3-3.R-1-0003",
+      "coverage_scope": "rule",
+      "expected_evidence": [
+        {
+          "id": "deforestation-threat-location-and-quantification",
+          "label": "Deforestation threat location and quantification",
+          "description": "Required: Deforestation threat location and quantification",
+          "required": true
+        }
+      ],
+      "expected_evidence_status": "seed_unverified",
+      "section_refs": [
+        {
+          "relationship": "source_section",
+          "section_id": "S-5-3"
+        }
+      ],
+      "section_refs_status": "source_audited"
+    },
+    "source_span_status": "source_audited",
+    "source_span_text": "",
+    "quality_status": "source_audited",
+    "when": []
+  },
+  {
+    "id": "Verra.VMD0007.v3-3.R-1-0004",
+    "stable_id": "Verra.VMD0007.v3-3.R-1-0004",
+    "summary": "Carbon stock change estimation",
+    "logic": "Carbon stock changes and GHG emissions estimated per Part 4 using carbon pool modules.",
+    "type": "calc",
+    "refs": {
+      "methodology": "Verra/VMD0007@v3-3",
+      "primary_section": "S-5-4",
+      "section_anchor": "part-4-estimation-of-carbon-stock-changes-and-ghg-emissions",
+      "section_number": "5.4",
+      "section_stable_id": "Verra.VMD0007.v3-3.S-5-4",
+      "sections": [
+        "S-5-4"
+      ],
+      "tools": [
+        "Verra/VMD0007@v3-3",
+        "Verra/VMD0001@v1-8",
+        "Verra/VMD0002@v1-8",
+        "Verra/VMD0003@v1-8",
+        "Verra/VMD0004@v1-8",
+        "Verra/VMD0005@v1-8"
+      ]
+    },
+    "section_context": {
+      "section_id": "S-5-4",
+      "section_ref": "Verra.VMD0007.v3-3.S-5-4",
+      "section_title": "Part 4: Estimation of Carbon Stock Changes and GHG Emissions",
+      "anchor": "part-4-estimation-of-carbon-stock-changes-and-ghg-emissions",
+      "lineage": [
+        "part-4-estimation-of-carbon-stock-changes-and-ghg-emissions"
+      ],
+      "locator_status": "pending_source_audit",
+      "page_start": 30,
+      "page_end": 35
+    },
+    "rule_detail": {
+      "summary": "Carbon stock change estimation",
+      "conditions": [
+        "Carbon stock changes and GHG emissions estimated per Part 4 using carbon pool modules."
+      ],
+      "exceptions": [],
+      "status": "seed_unverified"
+    },
+    "requirement_coverage": {
+      "coverage_key": "Verra.VMD0007.v3-3.R-1-0004",
+      "coverage_scope": "rule",
+      "expected_evidence": [
+        {
+          "id": "carbon-stock-change-estimation",
+          "label": "Carbon stock change estimation",
+          "description": "Required: Carbon stock change estimation",
+          "required": true
+        }
+      ],
+      "expected_evidence_status": "seed_unverified",
+      "section_refs": [
+        {
+          "relationship": "source_section",
+          "section_id": "S-5-4"
+        }
+      ],
+      "section_refs_status": "pending_source_audit"
+    },
+    "source_span_status": "seed_extracted_pending_source_audit",
+    "source_span_text": "",
+    "quality_status": "draft_unverified",
+    "when": []
+  }
+]

--- a/tools/Verra/VMD0007/v3-3/sections.json
+++ b/tools/Verra/VMD0007/v3-3/sections.json
@@ -1,0 +1,136 @@
+{
+  "sections": [
+    {
+      "id": "S-1",
+      "stable_id": "Verra.VMD0007.v3-3.S-1",
+      "title": "Sources",
+      "anchor": "sources",
+      "section_number": "1",
+      "section_level": 1,
+      "parent_id": null,
+      "page_start": 4,
+      "page_end": 4,
+      "locator_status": "source_audited"
+    },
+    {
+      "id": "S-2",
+      "stable_id": "Verra.VMD0007.v3-3.S-2",
+      "title": "Summary Description of the Module",
+      "anchor": "summary-description-of-the-module",
+      "section_number": "2",
+      "section_level": 1,
+      "parent_id": null,
+      "page_start": 5,
+      "page_end": 5,
+      "locator_status": "source_audited"
+    },
+    {
+      "id": "S-3",
+      "stable_id": "Verra.VMD0007.v3-3.S-3",
+      "title": "Definitions and Acronyms",
+      "anchor": "definitions-and-acronyms",
+      "section_number": "3",
+      "section_level": 1,
+      "parent_id": null,
+      "page_start": 5,
+      "page_end": 6,
+      "locator_status": "source_audited"
+    },
+    {
+      "id": "S-4",
+      "stable_id": "Verra.VMD0007.v3-3.S-4",
+      "title": "Applicability Conditions",
+      "anchor": "applicability-conditions",
+      "section_number": "4",
+      "section_level": 1,
+      "parent_id": null,
+      "page_start": 7,
+      "page_end": 7,
+      "locator_status": "source_audited"
+    },
+    {
+      "id": "S-5",
+      "stable_id": "Verra.VMD0007.v3-3.S-5",
+      "title": "Procedures",
+      "anchor": "procedures",
+      "section_number": "5",
+      "section_level": 1,
+      "parent_id": null,
+      "page_start": 7,
+      "page_end": 35,
+      "locator_status": "source_audited"
+    },
+    {
+      "id": "S-5-1",
+      "stable_id": "Verra.VMD0007.v3-3.S-5-1",
+      "title": "Part 1: Definition of Boundaries",
+      "anchor": "part-1-definition-of-boundaries",
+      "section_number": "5.1",
+      "section_level": 2,
+      "parent_id": "S-5",
+      "page_start": 8,
+      "page_end": 14,
+      "locator_status": "source_audited"
+    },
+    {
+      "id": "S-5-2",
+      "stable_id": "Verra.VMD0007.v3-3.S-5-2",
+      "title": "Part 2: Estimation of Annual Areas of Unplanned Deforestation",
+      "anchor": "part-2-estimation-of-annual-areas-of-unplanned-deforestation",
+      "section_number": "5.2",
+      "section_level": 2,
+      "parent_id": "S-5",
+      "page_start": 15,
+      "page_end": 24,
+      "locator_status": "source_audited"
+    },
+    {
+      "id": "S-5-3",
+      "stable_id": "Verra.VMD0007.v3-3.S-5-3",
+      "title": "Part 3: Location and Quantification of Threat",
+      "anchor": "part-3-location-and-quantification-of-threat",
+      "section_number": "5.3",
+      "section_level": 2,
+      "parent_id": "S-5",
+      "page_start": 25,
+      "page_end": 29,
+      "locator_status": "source_audited"
+    },
+    {
+      "id": "S-5-4",
+      "stable_id": "Verra.VMD0007.v3-3.S-5-4",
+      "title": "Part 4: Estimation of Carbon Stock Changes and GHG Emissions",
+      "anchor": "part-4-estimation-of-carbon-stock-changes-and-ghg-emissions",
+      "section_number": "5.4",
+      "section_level": 2,
+      "parent_id": "S-5",
+      "page_start": 30,
+      "page_end": 35,
+      "locator_status": "source_audited"
+    },
+    {
+      "id": "S-6",
+      "stable_id": "Verra.VMD0007.v3-3.S-6",
+      "title": "Parameters",
+      "anchor": "parameters",
+      "section_number": "6",
+      "section_level": 1,
+      "parent_id": null,
+      "page_start": 36,
+      "page_end": 46,
+      "locator_status": "source_audited"
+    },
+    {
+      "id": "S-7",
+      "stable_id": "Verra.VMD0007.v3-3.S-7",
+      "title": "References and Other Information",
+      "anchor": "references-and-other-information",
+      "section_number": "7",
+      "section_level": 1,
+      "parent_id": null,
+      "page_start": 47,
+      "page_end": 49,
+      "locator_status": "source_audited"
+    }
+  ]
+}

--- a/tools/Verra/VMD0007/v3-3/sections.rich.json
+++ b/tools/Verra/VMD0007/v3-3/sections.rich.json
@@ -1,0 +1,216 @@
+[
+  {
+    "id": "S-1",
+    "stable_id": "Verra.VMD0007.v3-3.S-1",
+    "title": "Sources",
+    "anchor": "sources",
+    "heading_text": "Sources",
+    "section_number": "1",
+    "section_level": 1,
+    "parent_id": null,
+    "page_start": 4,
+    "page_end": 4,
+    "locator_status": "source_audited",
+    "source_span_status": "source_audited",
+    "children": [],
+    "provenance": {
+      "source_hash": "c5f81df7bd65affae8686a40e27f1cfa0c90ca88b3c1fbf6a9ad5ee30398d499",
+      "source_ref": "Verra/VMD0007@v3-3"
+    }
+  },
+  {
+    "id": "S-2",
+    "stable_id": "Verra.VMD0007.v3-3.S-2",
+    "title": "Summary Description of the Module",
+    "anchor": "summary-description-of-the-module",
+    "heading_text": "Summary Description of the Module",
+    "section_number": "2",
+    "section_level": 1,
+    "parent_id": null,
+    "page_start": 5,
+    "page_end": 5,
+    "locator_status": "source_audited",
+    "source_span_status": "source_audited",
+    "children": [],
+    "provenance": {
+      "source_hash": "c5f81df7bd65affae8686a40e27f1cfa0c90ca88b3c1fbf6a9ad5ee30398d499",
+      "source_ref": "Verra/VMD0007@v3-3"
+    }
+  },
+  {
+    "id": "S-3",
+    "stable_id": "Verra.VMD0007.v3-3.S-3",
+    "title": "Definitions and Acronyms",
+    "anchor": "definitions-and-acronyms",
+    "heading_text": "Definitions and Acronyms",
+    "section_number": "3",
+    "section_level": 1,
+    "parent_id": null,
+    "page_start": 5,
+    "page_end": 6,
+    "locator_status": "source_audited",
+    "source_span_status": "source_audited",
+    "children": [],
+    "provenance": {
+      "source_hash": "c5f81df7bd65affae8686a40e27f1cfa0c90ca88b3c1fbf6a9ad5ee30398d499",
+      "source_ref": "Verra/VMD0007@v3-3"
+    }
+  },
+  {
+    "id": "S-4",
+    "stable_id": "Verra.VMD0007.v3-3.S-4",
+    "title": "Applicability Conditions",
+    "anchor": "applicability-conditions",
+    "heading_text": "Applicability Conditions",
+    "section_number": "4",
+    "section_level": 1,
+    "parent_id": null,
+    "page_start": 7,
+    "page_end": 7,
+    "locator_status": "source_audited",
+    "source_span_status": "source_audited",
+    "children": [],
+    "provenance": {
+      "source_hash": "c5f81df7bd65affae8686a40e27f1cfa0c90ca88b3c1fbf6a9ad5ee30398d499",
+      "source_ref": "Verra/VMD0007@v3-3"
+    }
+  },
+  {
+    "id": "S-5",
+    "stable_id": "Verra.VMD0007.v3-3.S-5",
+    "title": "Procedures",
+    "anchor": "procedures",
+    "heading_text": "Procedures",
+    "section_number": "5",
+    "section_level": 1,
+    "parent_id": null,
+    "page_start": 7,
+    "page_end": 35,
+    "locator_status": "source_audited",
+    "source_span_status": "source_audited",
+    "children": [
+      "S-5-1",
+      "S-5-2",
+      "S-5-3",
+      "S-5-4"
+    ],
+    "provenance": {
+      "source_hash": "c5f81df7bd65affae8686a40e27f1cfa0c90ca88b3c1fbf6a9ad5ee30398d499",
+      "source_ref": "Verra/VMD0007@v3-3"
+    }
+  },
+  {
+    "id": "S-5-1",
+    "stable_id": "Verra.VMD0007.v3-3.S-5-1",
+    "title": "Part 1: Definition of Boundaries",
+    "anchor": "part-1-definition-of-boundaries",
+    "heading_text": "Part 1: Definition of Boundaries",
+    "section_number": "5.1",
+    "section_level": 2,
+    "parent_id": "S-5",
+    "page_start": 8,
+    "page_end": 14,
+    "locator_status": "source_audited",
+    "source_span_status": "source_audited",
+    "children": [],
+    "provenance": {
+      "source_hash": "c5f81df7bd65affae8686a40e27f1cfa0c90ca88b3c1fbf6a9ad5ee30398d499",
+      "source_ref": "Verra/VMD0007@v3-3"
+    }
+  },
+  {
+    "id": "S-5-2",
+    "stable_id": "Verra.VMD0007.v3-3.S-5-2",
+    "title": "Part 2: Estimation of Annual Areas of Unplanned Deforestation",
+    "anchor": "part-2-estimation-of-annual-areas-of-unplanned-deforestation",
+    "heading_text": "Part 2: Estimation of Annual Areas of Unplanned Deforestation",
+    "section_number": "5.2",
+    "section_level": 2,
+    "parent_id": "S-5",
+    "page_start": 15,
+    "page_end": 24,
+    "locator_status": "source_audited",
+    "source_span_status": "source_audited",
+    "children": [],
+    "provenance": {
+      "source_hash": "c5f81df7bd65affae8686a40e27f1cfa0c90ca88b3c1fbf6a9ad5ee30398d499",
+      "source_ref": "Verra/VMD0007@v3-3"
+    }
+  },
+  {
+    "id": "S-5-3",
+    "stable_id": "Verra.VMD0007.v3-3.S-5-3",
+    "title": "Part 3: Location and Quantification of Threat",
+    "anchor": "part-3-location-and-quantification-of-threat",
+    "heading_text": "Part 3: Location and Quantification of Threat",
+    "section_number": "5.3",
+    "section_level": 2,
+    "parent_id": "S-5",
+    "page_start": 25,
+    "page_end": 29,
+    "locator_status": "source_audited",
+    "source_span_status": "source_audited",
+    "children": [],
+    "provenance": {
+      "source_hash": "c5f81df7bd65affae8686a40e27f1cfa0c90ca88b3c1fbf6a9ad5ee30398d499",
+      "source_ref": "Verra/VMD0007@v3-3"
+    }
+  },
+  {
+    "id": "S-5-4",
+    "stable_id": "Verra.VMD0007.v3-3.S-5-4",
+    "title": "Part 4: Estimation of Carbon Stock Changes and GHG Emissions",
+    "anchor": "part-4-estimation-of-carbon-stock-changes-and-ghg-emissions",
+    "heading_text": "Part 4: Estimation of Carbon Stock Changes and GHG Emissions",
+    "section_number": "5.4",
+    "section_level": 2,
+    "parent_id": "S-5",
+    "page_start": 30,
+    "page_end": 35,
+    "locator_status": "source_audited",
+    "source_span_status": "source_audited",
+    "children": [],
+    "provenance": {
+      "source_hash": "c5f81df7bd65affae8686a40e27f1cfa0c90ca88b3c1fbf6a9ad5ee30398d499",
+      "source_ref": "Verra/VMD0007@v3-3"
+    }
+  },
+  {
+    "id": "S-6",
+    "stable_id": "Verra.VMD0007.v3-3.S-6",
+    "title": "Parameters",
+    "anchor": "parameters",
+    "heading_text": "Parameters",
+    "section_number": "6",
+    "section_level": 1,
+    "parent_id": null,
+    "page_start": 36,
+    "page_end": 46,
+    "locator_status": "source_audited",
+    "source_span_status": "source_audited",
+    "children": [],
+    "provenance": {
+      "source_hash": "c5f81df7bd65affae8686a40e27f1cfa0c90ca88b3c1fbf6a9ad5ee30398d499",
+      "source_ref": "Verra/VMD0007@v3-3"
+    }
+  },
+  {
+    "id": "S-7",
+    "stable_id": "Verra.VMD0007.v3-3.S-7",
+    "title": "References and Other Information",
+    "anchor": "references-and-other-information",
+    "heading_text": "References and Other Information",
+    "section_number": "7",
+    "section_level": 1,
+    "parent_id": null,
+    "page_start": 47,
+    "page_end": 49,
+    "locator_status": "source_audited",
+    "source_span_status": "source_audited",
+    "children": [],
+    "provenance": {
+      "source_hash": "c5f81df7bd65affae8686a40e27f1cfa0c90ca88b3c1fbf6a9ad5ee30398d499",
+      "source_ref": "Verra/VMD0007@v3-3"
+    }
+  }
+]

--- a/tools/Verra/VMD0007/v3-3/source.pdf
+++ b/tools/Verra/VMD0007/v3-3/source.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5f81df7bd65affae8686a40e27f1cfa0c90ca88b3c1fbf6a9ad5ee30398d499
+size 800330

--- a/tools/Verra/VMD0007/v3-3/tool-META.json
+++ b/tools/Verra/VMD0007/v3-3/tool-META.json
@@ -1,0 +1,23 @@
+{
+  "doc": "Verra/VMD0007@v3-3",
+  "kind": "pdf",
+  "path": "tools/Verra/VMD0007/v3-3/source.pdf",
+  "sha256": "c5f81df7bd65affae8686a40e27f1cfa0c90ca88b3c1fbf6a9ad5ee30398d499",
+  "size": 800330,
+  "title": "VMD0007 Estimation of baseline carbon stock changes and greenhouse gas emissions from unplanned deforestation and unplanned wetland degradation (BL-UP), v3.3",
+  "version": "v3-3",
+  "standard": "Verra",
+  "type": "module",
+  "active_date": "2020-09-08",
+  "provenance": {
+    "source_pdfs": [
+      {
+        "doc": "Verra/VMD0007@v3-3",
+        "kind": "pdf",
+        "path": "tools/Verra/VMD0007/v3-3/source.pdf",
+        "sha256": "c5f81df7bd65affae8686a40e27f1cfa0c90ca88b3c1fbf6a9ad5ee30398d499",
+        "size": 800330
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What

VF S4: Encode VMD0007 and promote 3 VM0007 rules.

- **VMD0007 v3.3 encoded**: Source PDF, sections, rules, tool-META at `tools/Verra/VMD0007/v3-3/`.
- **3 VM0007 rules promoted** (all VMD0007-backed):
  - R-1-0003 (AUDef agent criteria)
  - R-1-0013 (AUWD agent criteria)
  - R-2-0004 (REDD reference region definition)
- **R-3-0005 and R-6-0005 remain draft_unverified**: still blocked by VMD0006 and VMD0015 respectively.
- **VM0007**: 30 source_audited, 28 draft_unverified.
- **Blocker inventory**: 28 entries.
- **META**: VMD0007 dep status → historical_non_blocking, local_artifact_present: true, registered in references.tools.
- **Roadmap**: VF S4 completed, VF S5 VMD0006 encoding next.

## Why

VMD0007 blocked the most rules (3 cleanly promotable). Two rules with additional deps kept truthful as blocked.

## Boundary

- VM0007 remains not S-grade (methodology_linked_review_ready: false).
- VM0047 S-grade unchanged.
- No app wiring.

Signed-off-by: Fred Egbuedike <Fredilly@article6.org>
