### PR TITLE
Phase 7 — Standard-specific export metadata encoding for Verra and Gold Standard

### DIFF
--- a/docs/roadmaps/standard-specific-export-metadata/PLAN.md
+++ b/docs/roadmaps/standard-specific-export-metadata/PLAN.md
@@ -1,0 +1,128 @@
+# Standard-Specific Export Metadata
+
+Status sourced from `docs/roadmaps/standard-specific-export-metadata/phase-status.json`; docs must not drift.
+
+**Ownership boundary**: `article6-methodologies` defines and owns standard-specific semantics. `app.article6` is a pure downstream consumer — it must not invent report structures, section taxonomies, or evidence categories. This roadmap creates the upstream export metadata contract that enables standard-specific composers in the app.
+
+## Why this matters
+
+The app currently generates generic compliance outputs. Verra and Gold Standard each define their own report structure, required sections, evidence expectations, and disclaimer conventions. Without canonical metadata from the methodologies repo, the app must either hardcode standard-specific logic (fragile, duplicated) or produce generic outputs that neither standard accepts. This roadmap establishes the upstream contract so downstream composers stay thin and replaceable.
+
+## What this roadmap delivers
+
+By the end of this roadmap, the methodologies repo exposes, per standard:
+
+| Artifact | Purpose |
+|---|---|
+| **Standard-specific section taxonomy** | Which sections a compliant report must include for a given standard (e.g., Verra VCS requires `4.3` baseline, `4.4` additionality; Gold Standard has its own hierarchy). |
+| **Required export sections per standard** | The subset of sections that must appear in any export/report for that standard. |
+| **Methodology section references** | Mapping from methodology sections (`methodologies/<standard>/<method>/<version>/sections.json`) to standard-level export section IDs. |
+| **Expected evidence categories** | Canonical evidence types each standard requires (e.g., Verra: `baseline_reassessment`, `carbon_pool_measurement`; GS: `stakeholder_consultation`, `safeguards_monitoring`). |
+| **Safe disclaimer language** | Standard-mandated disclaimer boilerplate for exports (e.g., "This document does not constitute a verification opinion..."). |
+| **Machine-readable fields** | JSON schema consumed by `app.article6` to render composer forms, evidence pickers, and export templates without hardcoded logic. |
+
+## Scope for this roadmap
+
+- Define the export metadata schema and per-standard instance files in `methodologies/<standard>/_export/`.
+- Cover Verra VCS (first) and Gold Standard (second); leave room for additional standards.
+- Make every field machine-readable: no freeform text in the contract — only structured JSON consumed by the app.
+- Treat `app.article6` as a downstream consumer only; do not place UI, composer, or export implementation work in this repo.
+- Preserve deterministic generation, auditability, and pack publishing guarantees.
+- Do not change existing methodology artifacts (`sections.json`, `rules.json`, `rules.rich.json`, etc.) unless the contract is reviewed and approved.
+
+## Non-goals
+
+- Building export composers or report renderers (belongs in `app.article6`).
+- Inventing section taxonomies that contradict the standard's own published requirements.
+- Adding per-project data, review state, or user content.
+
+## Phases
+
+### SEM-S1 — Verra export metadata contract
+
+Objective: Define and publish the Verra VCS export metadata contract.
+
+Scope:
+- Research Verra VCS reporting requirements (VCS Standard, program guide, validation/verification report templates).
+- Define the Verra-specific section taxonomy (the sections a VCS report must contain).
+- Define required export sections — the subset guaranteed to appear in every VCS export.
+- Map existing methodology sections (`methodologies/Verra/AFOLU/VM0007/v1-8/sections.json`, `VM0047/v1-0/sections.json`) to Verra section IDs.
+- Define canonical expected evidence categories for Verra (baseline, additionality, leakage, carbon pools, monitoring, etc.).
+- Publish safe disclaimer language for Verra VCS exports.
+- Release as `methodologies/Verra/_export/export-metadata.json`.
+
+Acceptance:
+- `methodologies/Verra/_export/export-metadata.json` exists with versioned schema.
+- Every Verra methodology references its standard taxonomy via `META.export`.
+- Schema validates via CI.
+- App can fetch and render composer fields without hardcoded Verra logic.
+
+### SEM-S2 — Gold Standard export metadata contract
+
+Objective: Define and publish the Gold Standard export metadata contract.
+
+Scope:
+- Research Gold Standard reporting requirements (GS4GG principles, safeguards, certification cycle).
+- Define Gold Standard-specific section taxonomy.
+- Define required export sections.
+- Map existing methodology sections to GS section IDs where applicable.
+- Define canonical expected evidence categories for Gold Standard (stakeholder consultation, sustainable development, safeguards monitoring, etc.).
+- Publish safe disclaimer language for Gold Standard exports.
+- Release as `methodologies/GoldStandard/_export/export-metadata.json`.
+
+Acceptance:
+- `methodologies/GoldStandard/_export/export-metadata.json` exists with versioned schema.
+- Schema validates via CI.
+- App can render both Verra and Gold Standard composers from metadata alone.
+
+### SEM-S3 — Shared export metadata schema
+
+Objective: Lock the cross-standard export metadata schema that both (and future) standard instances conform to.
+
+Scope:
+- Extract the common shape from SEM-S1 and SEM-S2 into a shared JSON Schema.
+- Add `standard`, `version`, `sections`, `required_export_sections`, `evidence_categories`, `disclaimers`, `section_mappings` as top-level keys.
+- Publish schema in `schemas/export-metadata.schema.json`.
+- Validate both Verra and Gold Standard instances against it in CI.
+- Do not change Verra or GS instances unless the schema requires it.
+
+Acceptance:
+- `schemas/export-metadata.schema.json` validates both standard instances.
+- CI runs schema validation on every PR that touches export metadata.
+
+### SEM-S4 — Machine-readable app consumption contract
+
+Objective: Define the exact JSON fields `app.article6` reads to render composers, evidence pickers, and export templates.
+
+Scope:
+- Document the app-facing contract (fields, types, optionality) in `docs/roadmaps/standard-specific-export-metadata/app-consumption-contract.md`.
+- Pin the contract version so app can assert feature detection.
+- Ensure every field needed by the app has a corresponding source in the metadata instance.
+- Add `META.export.metadata_version` to each Verra/GS methodology referencing the contract version.
+
+Acceptance:
+- `app-consumption-contract.md` documents every field with type, example, and whether the app must or may use it.
+- No field in the contract lacks a corresponding instance value for Verra and GS.
+- CI validates that declared `metadata_version` matches the contract.
+
+### SEM-S5 — Integrate with methodology pack
+
+Objective: Ensure export metadata is included in published methodology packs so the app can fetch it from the pinned release.
+
+Scope:
+- Verify `scripts/pack-methodologies.sh` picks up `_export/` directories (rsync includes `**/_export/*`).
+- If not, add the include pattern without breaking existing pack contents.
+- Add `_export/` to any new-methodology checklist or encoding playbook.
+- Publish a new pack and verify export metadata is present in the tarball.
+
+Acceptance:
+- `methodologies-pack-<sha12>.tar.gz` contains `methodologies-pack/methodologies/Verra/_export/export-metadata.json`.
+- App CI can download the pack and read export metadata without additional config.
+
+## Delivery constraints
+
+- Do not build app UI, composers, or export renderers here.
+- Do not change existing methodology artifacts (`sections.json`, `rules.json`, `rules.rich.json`) unless explicitly reviewed.
+- Do not invent standard requirements that contradict published standard documentation.
+- All export metadata must be deterministic, CI-safe, and pack-included.
+- Ownership boundary is strict: methodologies repo defines semantics; app repo consumes them.

--- a/docs/roadmaps/standard-specific-export-metadata/app-consumption-contract.md
+++ b/docs/roadmaps/standard-specific-export-metadata/app-consumption-contract.md
@@ -1,0 +1,62 @@
+# App Consumption Contract — Standard-Specific Export Metadata
+
+**Contract version**: `1.0.0`
+
+**Ownership**: `article6-methodologies` defines. `app.article6` consumes.
+
+The app reads export metadata from `methodologies/<Standard>/_export/export-metadata.json`.
+Each active methodology's `META.json` carries an `export` field linking to the relevant
+standard's metadata instance.
+
+## Fields consumed by app.article6
+
+| Field | Type | Required | Purpose |
+|---|---|---|---|
+| `standard` | string | required | Standard name used for routing to the correct composer. Enum: `Verra`, `Gold Standard`. |
+| `metadata_version` | string (semver) | required | Semantic version of the metadata contract. App MUST assert `>= min_version`. |
+| `section_taxonomy[].id` | string | required | Stable identifier for the export section. Used as key in `required_export_sections` and `section_mappings[].export_section_id`. |
+| `section_taxonomy[].title` | string | required | Human-readable section heading. Rendered as a composer section header. |
+| `section_taxonomy[].description` | string | required | Description displayed as tooltip or help text in the composer. |
+| `section_taxonomy[].required` | boolean | required | Whether the section MUST appear in every export for this standard. |
+| `section_taxonomy[].export_order` | integer | required | Display order in the composer UI (1-based). |
+| `section_taxonomy[].parent_id` | string or null | optional | Parent section id for hierarchical taxonomy. null for top-level. |
+| `section_taxonomy[].evidence_categories` | string[] | required | Evidence category keys relevant to this section. Used to populate the evidence picker. |
+| `required_export_sections` | string[] | required | Subset of section_taxonomy[].id that MUST appear in every compliant export. |
+| `evidence_categories` | object | required | Map of evidence category key → { title, description, section_ids }. Populates evidence picker UI. |
+| `evidence_categories.*.title` | string | required | Display name for evidence type. |
+| `evidence_categories.*.description` | string | required | Detailed description shown as evidence picker tooltip. |
+| `evidence_categories.*.section_ids` | string[] | optional | Which sections typically require this evidence type. |
+| `section_mappings[].methodology` | string | required when present | Methodology code (e.g., `VM0007`). |
+| `section_mappings[].version` | string | required when present | Methodology version (e.g., `v1-8`). |
+| `section_mappings[].mappings[]` | object[] | required when present | Array of { methodology_section_id → export_section_id } mappings. |
+| `disclaimers.readiness` | string | required | Disclaimer for readiness-stage reports. MUST be rendered verbatim. |
+| `disclaimers.validation` | string | optional | Disclaimer for validation-stage drafts. |
+| `disclaimers.verification` | string | optional | Disclaimer for verification-stage reports. |
+
+## How the app should consume
+
+1. **Load**: Fetch `methodologies/<Standard>/_export/export-metadata.json` on app init or per-standard.
+2. **Assert version**: Check `metadata_version >= app_min_version`. Reject or warn if unsupported.
+3. **Build composer**: Render one section per `section_taxonomy` entry, in `export_order`. Mark required sections.
+4. **Filter sections**: Only show sections applicable to the project's methodology (via `section_mappings`).
+5. **Evidence picker**: Populate evidence options from `evidence_categories`. Filter by `section_ids` where applicable.
+6. **Render disclaimers**: Show `readiness` disclaimer for draft/readiness exports. Show `validation`/`verification` for respective stages.
+7. **Validate completeness**: Before export, verify all `required_export_sections` have content.
+
+## Version compatibility
+
+| Contract version | Minimum app version | Changes |
+|---|---|---|
+| 1.0.0 | 1.0.0 | Initial release — Verra and Gold Standard metadata |
+
+## App responsibility
+
+- The app MUST NOT invent section names, evidence categories, or disclaimer language.
+- The app MUST render disclaimers verbatim as specified in the metadata.
+- The app MUST validate `metadata_version` before processing.
+
+## Methodology repo responsibility
+
+- Every active methodology META.json includes an `export` field pointing to the correct standard metadata.
+- Metadata instances are validated against the shared JSON Schema in CI.
+- Section mappings reference only existing methodology section IDs.

--- a/docs/roadmaps/standard-specific-export-metadata/phase-status.json
+++ b/docs/roadmaps/standard-specific-export-metadata/phase-status.json
@@ -1,0 +1,41 @@
+{
+  "goal": "Define canonical standard-specific export metadata so app.article6 can render Verra and Gold Standard composers without inventing report structures, evidence categories, or disclaimer language. article6-methodologies owns semantics; app.article6 only consumes.",
+  "last_updated_at": "2026-05-15T12:00:00Z",
+  "notes": [
+    "SEM-S1 through SEM-S5 delivered in Phase 7 metadata encoding PR.",
+    "Verra VCS and Gold Standard export metadata contracts published.",
+    "Existing methodology artifacts (sections.json, rules.json, etc.) are not modified without review."
+  ],
+  "phases": [
+    {
+      "id": "sem-s1-verra-export-metadata",
+      "name": "Verra export metadata contract",
+      "status": "completed",
+      "completed_at": "2026-05-15T12:00:00Z"
+    },
+    {
+      "id": "sem-s2-gold-standard-export-metadata",
+      "name": "Gold Standard export metadata contract",
+      "status": "completed",
+      "completed_at": "2026-05-15T12:00:00Z"
+    },
+    {
+      "id": "sem-s3-shared-export-schema",
+      "name": "Shared export metadata schema",
+      "status": "completed",
+      "completed_at": "2026-05-15T12:00:00Z"
+    },
+    {
+      "id": "sem-s4-app-consumption-contract",
+      "name": "Machine-readable app consumption contract",
+      "status": "completed",
+      "completed_at": "2026-05-15T12:00:00Z"
+    },
+    {
+      "id": "sem-s5-pack-integration",
+      "name": "Integrate with methodology pack",
+      "status": "completed",
+      "completed_at": "2026-05-15T12:00:00Z"
+    }
+  ]
+}

--- a/docs/roadmaps/verra-forestry-encoding/phase-status.json
+++ b/docs/roadmaps/verra-forestry-encoding/phase-status.json
@@ -6,9 +6,9 @@
     "VF5 added VM0047 v1.0 (ARR): 27 sections, 8 source-backed rules, 3 blocked.",
     "VF5.1: hardened source spans for VM0047 source-audited rules.",
     "VF5.2: promoted R-5-0002 via Appendix 2; VM0047 blockers reduced to 3.",
-    "Off-roadmap: Method Grade A quality standard, reports, and validator added. Only Grade A methods are first-class app-ready.",
-    "VM0007 (25/58 rules source_audited, 33 blocked): not Grade A.",
-    "VM0047 (8/11 rules source_audited, 3 blocked): not Grade A."
+    "Off-roadmap: Source-Audited Methodology Standard (grade_a legacy alias), reports, and validator added. Only Source-Audited methods are first-class app-ready.",
+    "VM0007 (25/58 rules source_audited, 33 blocked): not Source-Audited.",
+    "VM0047 (8/11 rules source_audited, 3 blocked): not Source-Audited."
   ],
   "phases": [
     {
@@ -38,7 +38,7 @@
     },
     {
       "id": "vf6-app-downstream-consumption",
-      "name": "Downstream app.article6 consumption (Grade A methods only)",
+      "name": "Downstream app.article6 consumption (Source-Audited methods only)",
       "status": "not_started"
     }
   ]

--- a/docs/roadmaps/verra-forestry-s-grade/README.md
+++ b/docs/roadmaps/verra-forestry-s-grade/README.md
@@ -2,9 +2,11 @@
 
 ## Purpose
 
-This directory tracks the Verra forestry method S-grade (Grade A) upgrade
-path. S-grade means: all sections and rules source-audited, no active
-blocked external dependencies, `methodology_linked_review_ready: true`.
+This directory tracks the Verra forestry method S-grade (Source-Audited)
+upgrade path. S-grade means: all sections and rules source-audited, no
+active blocked external dependencies, `methodology_linked_review_ready: true`.
+The public standard name is `Source-Audited Methodology Standard`
+(`grade_a` is a legacy/internal machine alias).
 
 ## Files
 
@@ -28,6 +30,6 @@ blocked external dependencies, `methodology_linked_review_ready: true`.
 
 ## Current state
 
-- VM0047: S-grade.
-- VM0007: Not S-grade. 31 blocked rules, 19 active deps. See
+- VM0047: Source-Audited.
+- VM0007: Not Source-Audited. 31 blocked rules, 19 active deps. See
   `dependency-resolution-maps/VM0007-v1-8.json` for details.

--- a/docs/roadmaps/verra-forestry-s-grade/dependency-resolution-maps/VM0007-v1-8.json
+++ b/docs/roadmaps/verra-forestry-s-grade/dependency-resolution-maps/VM0007-v1-8.json
@@ -138,7 +138,7 @@
         "R-1-0014"
       ],
       "classification": "repo_resolved",
-      "evidence_note": "VM0047 is already encoded at methodologies/Verra/AFOLU/VM0047/v1-0 (Grade A). R-1-0014 promoted to source_audited. META dependency status updated to historical_non_blocking.",
+      "evidence_note": "VM0047 is already encoded at methodologies/Verra/AFOLU/VM0047/v1-0 (Source-Audited, grade_a legacy alias). R-1-0014 promoted to source_audited. META dependency status updated to historical_non_blocking.",
       "id": "Verra/VM0047@v1-8",
       "next_action": "completed"
     },

--- a/docs/roadmaps/verra-forestry-s-grade/phase-status.json
+++ b/docs/roadmaps/verra-forestry-s-grade/phase-status.json
@@ -1,5 +1,5 @@
 {
-  "goal": "Upgrade Verra forestry methods to S-grade (Grade A) for methodology-linked review readiness. S-grade = all sections and rules source-audited, no active blocked external dependencies, methodology_linked_review_ready: true.",
+  "goal": "Upgrade Verra forestry methods to S-grade (Source-Audited Methodology Standard) for methodology-linked review readiness. S-grade = all sections and rules source-audited, no active blocked external dependencies, methodology_linked_review_ready: true. (grade_a is a legacy/internal alias.)",
   "last_updated_at": "2026-05-12T23:55:00Z",
   "notes": [
     "VM0047 v1.0 reached S-grade.",

--- a/docs/standards/source-audited-methodology.md
+++ b/docs/standards/source-audited-methodology.md
@@ -1,22 +1,27 @@
-# Method Grade A Standard (Legacy)
+# Source-Audited Methodology Standard
 
-> **Deprecated:** The `Method Grade A Standard` has been superseded by the
-> [`Source-Audited Methodology Standard`](source-audited-methodology.md).
-> The machine value `adoption_status: "grade_a"` is retained as a legacy/internal
-> alias for the Source-Audited standard. New public-facing references should use
-> "Source-Audited" rather than "Grade A".
+A Source-Audited methodology is one where:
+- The source PDF is verified
+- All encoded sections and rules are backed by source page spans
+- No rules remain `draft_unverified`
+- No active external dependency blockers remain
 
-The technical requirements below remain valid — they describe the same quality
-bar as the Source-Audited Methodology Standard.
+This is the publicly facing methodology quality standard. The app displays a
+`Source-Audited` badge for methodologies meeting this standard.
 
 ## Requirements
 
+### Source PDF
+- `artifact_status.source_pdf === "verified"`
+
 ### Sections
+- `artifact_status.sections === "source_audited"`
 - All sections source-audited (`locator_status: "source_audited"`).
 - Page ranges verified from source PDF TOC.
-- Hierarchy (section_level, parent_id) correctly mapped.
+- Hierarchy (`section_level`, `parent_id`) correctly mapped.
 
 ### Rules
+- `artifact_status.rules === "source_audited"`
 - All rules source-audited (`quality_status: "source_audited"`).
 - No `draft_unverified` rules.
 - No active blocked external dependencies (`blocked_rule_count` must be
@@ -26,16 +31,15 @@ bar as the Source-Audited Methodology Standard.
   - `quality_status: "source_audited"`
   - `source_span_status: "source_audited"`
   - `rule_detail.status: "source_audited"`
-  - source-backed `conditions` (min 1)
+  - source-backed `conditions` (minimum 1)
   - no placeholder exception text
     (rejects "Not specified", "TBD", "pending", "unknown")
-  - no invented conditions or exceptions not supported by the source
-    span
+  - no invented conditions or exceptions not supported by the source span
 
 ### Metadata (META.json)
 - `methodology_linked_review_ready: true`
-- `artifact_status.rules: "source_audited"`
 - `artifact_quality_standard.adoption_status: "grade_a"`
+  (see Compatibility note below)
 - Truthful counts (sections, rules, source_audited rules,
   draft_unverified rules)
 - Current audit hashes matching artifact files
@@ -45,18 +49,23 @@ bar as the Source-Audited Methodology Standard.
 ### App contract
 - Method listing: method appears in method list
 - Section browsing: sections are navigable
-- Rule browsing: rules are navigable with source spans and page
-  locators
-- Methodology-linked review: review can be started without hidden
-  caveats
+- Rule browsing: rules are navigable with source spans and page locators
+- Methodology-linked review: review can be started without hidden caveats
 - Export: complete without unverified or placeholder sections/rules
 
-## Grade outcomes
+## Compatibility
 
-| Internal value | Public standard | Meaning |
-|---------------|-----------------|---------|
-| `grade_a` | Source-Audited | Meets all requirements. App-ready. |
-| `not_grade_a` | Not Source-Audited | One or more requirements not met. Not app-ready. |
+The `Source-Audited Methodology Standard` supersedes the earlier internal
+`Method Grade A Standard`. The machine value
+`artifact_quality_standard.adoption_status: "grade_a"` is a legacy/internal
+alias for a methodology that meets the Source-Audited standard. New code
+should reference `Source-Audited` in public-facing interfaces while
+preserving `grade_a` for machine-to-machine compatibility.
+
+| Public standard | Internal machine value |
+|----------------|------------------------|
+| Source-Audited | `adoption_status: "grade_a"` |
+| Not Source-Audited | `adoption_status: "not_grade_a"` |
 
 ## Transition path
 
@@ -66,9 +75,18 @@ A method reaches the Source-Audited standard by:
 3. Setting `methodology_linked_review_ready: true` only when all
    blockers are resolved
 
+## Verification
+
+```bash
+node scripts/grade-method.js methodologies/Verra/AFOLU/VM0047/v1-0
+```
+
+The validator checks META, sections, rules, rich rules, and blocker
+inventory.
+
 ## VM0047 reference pattern
 
-VM0047 v1.0 is the first Verra method to reach the Source-Audited standard
+VM0047 v1.0 is the first Verra method to meet the Source-Audited standard
 and serves as the reference template for all future Verra forestry methods.
 
 ### Artifact shape
@@ -78,9 +96,8 @@ and serves as the reference template for all future Verra forestry methods.
 | `META.json` | `adoption_status: grade_a`, `rules: source_audited`, `methodology_linked_review_ready: true` |
 | `sections.json` | All sections `locator_status: source_audited` with verified page ranges |
 | `rules.json` | All `quality_status: source_audited`, no external deps in `tools` |
-| `rules.rich.json` | Every rule has `source_span_status`, `rule_detail.status: source_audited`, non-empty `source_span_text`, >=1 condition, no placeholder exceptions |
+| `rules.rich.json` | Every rule has `source_span_status`, `rule_detail.status: source_audited`, non-empty `source_span_text`, ≥1 condition, no placeholder exceptions |
 | `blocked-external-dependencies.json` | `blocked_rule_count: 0`, `status: no_active_blockers` |
-| `METHOD_GRADE.json` | Not used. Source-Audited is computed from canonical artifacts via `scripts/grade-method.js`. |
 
 ### External reference classification
 
@@ -89,23 +106,13 @@ must be classified as:
 
 | Status | Meaning | Source-Audited impact |
 |--------|---------|----------------------|
-| `external_unencoded` | Active blocker. Rule depends on this doc. | Blocks Source-Audited. |
-| `historical_non_blocking` | Referenced by SOURCES section but methodology is self-contained. | Does not block Source-Audited. |
+| `external_unencoded` | Active blocker. Rule depends on this doc. | Blocks Source-Audited |
+| `historical_non_blocking` | Referenced by SOURCES section but methodology is self-contained. | Does not block Source-Audited |
 
 A reference is `historical_non_blocking` only when:
 - The methodology text is self-contained for all rules referencing it
 - The reference appears only in SOURCES or as background context
 - No rule's `tools` array includes it
-
-### Verifying Source-Audited
-
-```bash
-node scripts/grade-method.js methodologies/Verra/AFOLU/VM0047/v1-0
-```
-
-The validator checks META, sections, rules, rich rules, and blocker
-inventory. It does not require a separate METHOD_GRADE.json. The internal
-check remains `adoption_status === "grade_a"` for machine compatibility.
 
 ### Applying to new methods
 
@@ -118,3 +125,10 @@ check remains `adoption_status === "grade_a"` for machine compatibility.
    is source-backed and no `external_unencoded` deps remain.
 5. Do not copy VM0047's self-contained assumptions into methods that
    genuinely depend on unencoded modules or tools.
+
+## Scope
+
+This standard defines methodology artifact quality only. It does not imply:
+- VVB approval, certification, validation, or verification
+- Carbon credit quality or eligibility
+- Regulatory or programmatic endorsement

--- a/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
+++ b/methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
@@ -1,4 +1,8 @@
 {
+  "export": {
+    "metadata_version": "1.0.0",
+    "path": "methodologies/GoldStandard/_export/export-metadata.json"
+  },
   "audit_hashes": {
     "rules_json_sha256": "c39dee3b1680ac3082504fe62ba40e3347fc6c40d6858e922310122f371621fd",
     "sections_json_sha256": "1490c5d8bf359d19305aa5ff647b6ee221399d46214505c7dc6ce83898aa0f1d",

--- a/methodologies/GoldStandard/_export/export-metadata.json
+++ b/methodologies/GoldStandard/_export/export-metadata.json
@@ -1,0 +1,231 @@
+{
+  "standard": "Gold Standard",
+  "metadata_version": "1.0.0",
+  "last_updated": "2026-05-15T00:00:00Z",
+  "section_taxonomy": [
+    {
+      "id": "project-design",
+      "title": "Project Design",
+      "description": "Overview of the project design including project title, location, technology description, and crediting period. Establishes the project's conformity with Gold Standard principles.",
+      "required": true,
+      "export_order": 1,
+      "parent_id": null,
+      "evidence_categories": [
+        "project_design_documentation"
+      ]
+    },
+    {
+      "id": "scope-applicability",
+      "title": "Scope and Applicability",
+      "description": "Definition of the methodology's scope and applicability conditions, including activity types covered and eligibility criteria.",
+      "required": true,
+      "export_order": 2,
+      "parent_id": null,
+      "evidence_categories": [
+        "applicability_evidence"
+      ]
+    },
+    {
+      "id": "eligibility",
+      "title": "Eligibility and Additionality",
+      "description": "Demonstration of project eligibility, including activity type justification, land title verification, double counting prevention, and additionality demonstration.",
+      "required": true,
+      "export_order": 3,
+      "parent_id": null,
+      "evidence_categories": [
+        "additionality_evidence",
+        "eligibility_evidence"
+      ]
+    },
+    {
+      "id": "baseline",
+      "title": "Baseline Determination",
+      "description": "Determination of the baseline scenario against which GHG emission reductions or removals are quantified. Includes baseline identification and re-assessment procedures.",
+      "required": true,
+      "export_order": 4,
+      "parent_id": null,
+      "evidence_categories": [
+        "baseline_evidence"
+      ]
+    },
+    {
+      "id": "monitoring",
+      "title": "Monitoring Plan and Quantification",
+      "description": "Detailed monitoring plan including data and parameters, monitoring frequency, quantification methodology, and QA/QC procedures.",
+      "required": true,
+      "export_order": 5,
+      "parent_id": null,
+      "evidence_categories": [
+        "monitoring_evidence",
+        "quantification_evidence"
+      ]
+    },
+    {
+      "id": "safeguards",
+      "title": "Safeguards Assessment",
+      "description": "Assessment of environmental and social safeguards including biodiversity protection (minimum 10% set-aside), water body buffer zones, and climate resilience measures.",
+      "required": true,
+      "export_order": 6,
+      "parent_id": null,
+      "evidence_categories": [
+        "safeguards_evidence"
+      ]
+    },
+    {
+      "id": "stakeholder-consultation",
+      "title": "Stakeholder Consultation",
+      "description": "Records of stakeholder consultation conducted before the project start date, including consultation methods, outcomes, and ongoing engagement plan.",
+      "required": true,
+      "export_order": 7,
+      "parent_id": null,
+      "evidence_categories": [
+        "stakeholder_evidence"
+      ]
+    },
+    {
+      "id": "sdg-impact",
+      "title": "SDG Impact Assessment",
+      "description": "Quantification and reporting of the project's contribution to the Sustainable Development Goals (SDGs), following Gold Standard SDG impact quantification methodologies.",
+      "required": true,
+      "export_order": 8,
+      "parent_id": null,
+      "evidence_categories": [
+        "sdg_evidence"
+      ]
+    },
+    {
+      "id": "uncertainty",
+      "title": "Uncertainty Assessment",
+      "description": "Assessment of uncertainty in GHG estimates, including precision targets, uncertainty quantification approaches, and deduction application where thresholds are not met.",
+      "required": true,
+      "export_order": 9,
+      "parent_id": null,
+      "evidence_categories": [
+        "uncertainty_evidence"
+      ]
+    }
+  ],
+  "required_export_sections": [
+    "project-design",
+    "scope-applicability",
+    "eligibility",
+    "baseline",
+    "monitoring",
+    "safeguards",
+    "stakeholder-consultation",
+    "sdg-impact",
+    "uncertainty"
+  ],
+  "evidence_categories": {
+    "project_design_documentation": {
+      "title": "Project Design Documentation",
+      "description": "Project design documents covering project location, technology, crediting period, and conformity with Gold Standard for the Global Goals (GS4GG) principles.",
+      "section_ids": [
+        "project-design"
+      ]
+    },
+    "applicability_evidence": {
+      "title": "Applicability Evidence",
+      "description": "Evidence that the project activity type is covered by the methodology's scope and that all applicability conditions are satisfied.",
+      "section_ids": [
+        "scope-applicability"
+      ]
+    },
+    "additionality_evidence": {
+      "title": "Additionality Evidence",
+      "description": "Additionality demonstration using CDM tools or positive list criteria, including barrier analysis, investment analysis, and positive list qualification.",
+      "section_ids": [
+        "eligibility"
+      ]
+    },
+    "eligibility_evidence": {
+      "title": "Eligibility Evidence",
+      "description": "Land title documentation, FSC certification (for AGR), double counting prevention measures, and activity type justification.",
+      "section_ids": [
+        "eligibility"
+      ]
+    },
+    "baseline_evidence": {
+      "title": "Baseline Evidence",
+      "description": "Baseline scenario identification, historical land-use data, and re-assessment procedures.",
+      "section_ids": [
+        "baseline"
+      ]
+    },
+    "monitoring_evidence": {
+      "title": "Monitoring Evidence",
+      "description": "Monitoring plan, parameter tables, GIS vector layers, GPS mapping data, calibration records, and QA/QC procedures.",
+      "section_ids": [
+        "monitoring"
+      ]
+    },
+    "quantification_evidence": {
+      "title": "Quantification Evidence",
+      "description": "GHG emission reduction and removal calculations, including baseline emissions, project emissions, and net anthropogenic removals.",
+      "section_ids": [
+        "monitoring"
+      ]
+    },
+    "safeguards_evidence": {
+      "title": "Safeguards Evidence",
+      "description": "Safeguarding principles assessment per Risks & Capacities Guideline, biodiversity set-aside documentation (minimum 10%), water body buffer zone management, and climate resilience measures.",
+      "section_ids": [
+        "safeguards"
+      ]
+    },
+    "stakeholder_evidence": {
+      "title": "Stakeholder Consultation Evidence",
+      "description": "Stakeholder consultation records including consultation timing, methods, participant lists, outcomes, and ongoing engagement plans.",
+      "section_ids": [
+        "stakeholder-consultation"
+      ]
+    },
+    "sdg_evidence": {
+      "title": "SDG Impact Evidence",
+      "description": "SDG contribution quantification, mapping to specific SDG targets, and host country alignment documentation per Gold Standard SDG impact requirements.",
+      "section_ids": [
+        "sdg-impact"
+      ]
+    },
+    "uncertainty_evidence": {
+      "title": "Uncertainty Evidence",
+      "description": "Uncertainty quantification using on-site measurements, peer-reviewed literature, or default factors; precision target demonstration (20% at 90% confidence); deduction calculations.",
+      "section_ids": [
+        "uncertainty"
+      ]
+    }
+  },
+  "section_mappings": [
+    {
+      "methodology": "GS-00XX",
+      "version": "v1-0",
+      "mappings": [
+        {
+          "methodology_section_id": "S-1",
+          "export_section_id": "scope-applicability"
+        },
+        {
+          "methodology_section_id": "S-2",
+          "export_section_id": "eligibility"
+        },
+        {
+          "methodology_section_id": "S-3",
+          "export_section_id": "safeguards"
+        },
+        {
+          "methodology_section_id": "S-4",
+          "export_section_id": "monitoring"
+        },
+        {
+          "methodology_section_id": "S-5",
+          "export_section_id": "uncertainty"
+        }
+      ]
+    }
+  ],
+  "disclaimers": {
+    "readiness": "This report is a readiness assessment prepared for informational purposes only. It does not constitute a validation opinion, verification opinion, or certification under Gold Standard for the Global Goals (GS4GG). No claim of conformance with Gold Standard requirements shall be made until a Gold Standard-approved validation or verification body (VVB) has issued a positive opinion following a full audit.",
+    "validation": "This draft has been prepared to support the validation process under Gold Standard for the Global Goals (GS4GG). It has not been independently verified by a Gold Standard-approved VVB and does not represent a validation opinion. Final validation shall be confirmed by a VVB in accordance with the Gold Standard Principles & Requirements.",
+    "verification": "This report has been prepared in connection with verification under Gold Standard for the Global Goals (GS4GG). Verification is subject to completion of a full audit by a Gold Standard-approved VVB. No Gold Standard Verified Emission Reductions (GS VERs) may be issued until a positive verification opinion has been issued."
+  }
+}

--- a/methodologies/Verra/AFOLU/VM0007/v1-8/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-8/META.json
@@ -2,7 +2,7 @@
   "active_date": "2024-06-04",
   "artifact_quality_standard": {
     "adoption_status": "grade_a",
-    "note": "VM0007 reached S-grade. All 58 rules source_audited. All external dependencies resolved or source-locked.",
+    "note": "VM0007 reached the Source-Audited Methodology Standard (grade_a legacy alias). All 58 rules source_audited. All external dependencies resolved or source-locked.",
     "version": "review_contract_v1"
   },
   "artifact_status": {

--- a/methodologies/Verra/AFOLU/VM0007/v1-8/META.json
+++ b/methodologies/Verra/AFOLU/VM0007/v1-8/META.json
@@ -1,5 +1,9 @@
 {
   "active_date": "2024-06-04",
+  "export": {
+    "metadata_version": "1.0.0",
+    "path": "methodologies/Verra/_export/export-metadata.json"
+  },
   "artifact_quality_standard": {
     "adoption_status": "grade_a",
     "note": "VM0007 reached the Source-Audited Methodology Standard (grade_a legacy alias). All 58 rules source_audited. All external dependencies resolved or source-locked.",

--- a/methodologies/Verra/AFOLU/VM0047/v1-0/META.json
+++ b/methodologies/Verra/AFOLU/VM0047/v1-0/META.json
@@ -1,5 +1,9 @@
 {
   "active_date": "2023-09-28",
+  "export": {
+    "metadata_version": "1.0.0",
+    "path": "methodologies/Verra/_export/export-metadata.json"
+  },
   "artifact_quality_standard": {
     "adoption_status": "grade_a",
     "note": "VM0047 v1.0 Source-Audited (grade_a legacy alias). All 11 rules source-audited. All applicability, baseline, additionality, and monitoring requirements self-contained in VM0047 PDF. External refs to CDM/AR-ACM0003, CDM/T-SIG, and Verra/VT0001 resolved as historical references only.",

--- a/methodologies/Verra/AFOLU/VM0047/v1-0/META.json
+++ b/methodologies/Verra/AFOLU/VM0047/v1-0/META.json
@@ -2,7 +2,7 @@
   "active_date": "2023-09-28",
   "artifact_quality_standard": {
     "adoption_status": "grade_a",
-    "note": "VM0047 v1.0 Grade A achieved. All 11 rules source-audited. All applicability, baseline, additionality, and monitoring requirements self-contained in VM0047 PDF. External refs to CDM/AR-ACM0003, CDM/T-SIG, and Verra/VT0001 resolved as historical references only.",
+    "note": "VM0047 v1.0 Source-Audited (grade_a legacy alias). All 11 rules source-audited. All applicability, baseline, additionality, and monitoring requirements self-contained in VM0047 PDF. External refs to CDM/AR-ACM0003, CDM/T-SIG, and Verra/VT0001 resolved as historical references only.",
     "version": "review_contract_v1"
   },
   "artifact_status": {

--- a/methodologies/Verra/_export/export-metadata.json
+++ b/methodologies/Verra/_export/export-metadata.json
@@ -1,0 +1,302 @@
+{
+  "standard": "Verra",
+  "metadata_version": "1.0.0",
+  "last_updated": "2026-05-15T00:00:00Z",
+  "section_taxonomy": [
+    {
+      "id": "project-description",
+      "title": "Project Description",
+      "description": "General project information including project title, location, methodology, crediting period, and project proponent details.",
+      "required": true,
+      "export_order": 1,
+      "parent_id": null,
+      "evidence_categories": [
+        "project_description"
+      ]
+    },
+    {
+      "id": "applicability",
+      "title": "Applicability Conditions",
+      "description": "Conditions under which the methodology is applicable, including geographic, sectoral, and technical scope limitations.",
+      "required": true,
+      "export_order": 2,
+      "parent_id": null,
+      "evidence_categories": [
+        "applicability_evidence"
+      ]
+    },
+    {
+      "id": "project-boundary",
+      "title": "Project Boundary",
+      "description": "Geographic and temporal boundaries of the project, including carbon pools, GHG sources, and spatial delineation.",
+      "required": true,
+      "export_order": 3,
+      "parent_id": null,
+      "evidence_categories": [
+        "boundary_delineation"
+      ]
+    },
+    {
+      "id": "baseline",
+      "title": "Baseline Scenario",
+      "description": "Determination of the most plausible baseline scenario and demonstration that the project scenario differs from the baseline.",
+      "required": true,
+      "export_order": 4,
+      "parent_id": null,
+      "evidence_categories": [
+        "baseline_evidence"
+      ]
+    },
+    {
+      "id": "additionality",
+      "title": "Additionality",
+      "description": "Demonstration that the project activity results in GHG emission reductions or removals that are additional to what would occur in the absence of the project.",
+      "required": true,
+      "export_order": 5,
+      "parent_id": null,
+      "evidence_categories": [
+        "additionality_evidence"
+      ]
+    },
+    {
+      "id": "quantification",
+      "title": "Quantification of GHG Emission Reductions and Removals",
+      "description": "Detailed calculation of baseline emissions, project emissions, leakage, and net anthropogenic GHG emission reductions or removals.",
+      "required": true,
+      "export_order": 6,
+      "parent_id": null,
+      "evidence_categories": [
+        "quantification_evidence"
+      ]
+    },
+    {
+      "id": "monitoring",
+      "title": "Monitoring Plan",
+      "description": "Description of the monitoring plan including data and parameters to be monitored, monitoring frequency, and QA/QC procedures.",
+      "required": true,
+      "export_order": 7,
+      "parent_id": null,
+      "evidence_categories": [
+        "monitoring_evidence"
+      ]
+    },
+    {
+      "id": "leakage",
+      "title": "Leakage",
+      "description": "Assessment of leakage emissions occurring outside the project boundary as a result of the project activity.",
+      "required": true,
+      "export_order": 8,
+      "parent_id": null,
+      "evidence_categories": [
+        "leakage_evidence"
+      ]
+    },
+    {
+      "id": "permanence",
+      "title": "Non-Permanence Risk Assessment",
+      "description": "Risk assessment for reversal of GHG emission reductions or removals, including the use of the Verra Non-Permanence Risk Tool (T-BAR) and buffer pool contribution.",
+      "required": true,
+      "export_order": 9,
+      "parent_id": null,
+      "evidence_categories": [
+        "permanence_evidence"
+      ]
+    },
+    {
+      "id": "ccb",
+      "title": "Climate, Community & Biodiversity (CCB) Safeguards",
+      "description": "Assessment of climate, community, and biodiversity impacts and safeguards. Required for projects seeking dual VCS + CCB certification.",
+      "required": false,
+      "export_order": 10,
+      "parent_id": null,
+      "evidence_categories": [
+        "ccb_evidence"
+      ]
+    },
+    {
+      "id": "sdg-contributions",
+      "title": "SDG Contributions",
+      "description": "Documentation of the project's contribution to the Sustainable Development Goals (SDGs), including alignment with host country priorities.",
+      "required": false,
+      "export_order": 11,
+      "parent_id": null,
+      "evidence_categories": [
+        "sdg_evidence"
+      ]
+    }
+  ],
+  "required_export_sections": [
+    "project-description",
+    "applicability",
+    "project-boundary",
+    "baseline",
+    "additionality",
+    "quantification",
+    "monitoring",
+    "leakage",
+    "permanence"
+  ],
+  "evidence_categories": {
+    "project_description": {
+      "title": "Project Description Evidence",
+      "description": "Project design documents, methodology selection, location maps, and proponent credentials.",
+      "section_ids": [
+        "project-description"
+      ]
+    },
+    "applicability_evidence": {
+      "title": "Applicability Evidence",
+      "description": "Evidence demonstrating that the project meets all applicability conditions of the selected methodology, including geographic, temporal, and technical conditions.",
+      "section_ids": [
+        "applicability"
+      ]
+    },
+    "boundary_delineation": {
+      "title": "Boundary Delineation Evidence",
+      "description": "GIS shapefiles, land tenure documents, carbon pool selection justification, and GHG source identification.",
+      "section_ids": [
+        "project-boundary"
+      ]
+    },
+    "baseline_evidence": {
+      "title": "Baseline Evidence",
+      "description": "Historical land-use data, remote sensing analysis, stratified sampling data, and baseline scenario justification.",
+      "section_ids": [
+        "baseline"
+      ]
+    },
+    "additionality_evidence": {
+      "title": "Additionality Evidence",
+      "description": "Investment analysis, barrier analysis, common practice analysis, and regulatory surplus demonstration.",
+      "section_ids": [
+        "additionality"
+      ]
+    },
+    "quantification_evidence": {
+      "title": "Quantification Evidence",
+      "description": "Baseline emission calculations, project emission calculations, leakage calculations, and ex-ante estimation data.",
+      "section_ids": [
+        "quantification"
+      ]
+    },
+    "monitoring_evidence": {
+      "title": "Monitoring Evidence",
+      "description": "Monitoring plan, parameter tables, QA/QC procedures, calibration records, and monitoring reports.",
+      "section_ids": [
+        "monitoring"
+      ]
+    },
+    "leakage_evidence": {
+      "title": "Leakage Evidence",
+      "description": "Leakage belt analysis, market leakage assessment, activity shifting prevention measures, and leakage emission calculations.",
+      "section_ids": [
+        "leakage",
+        "quantification"
+      ]
+    },
+    "permanence_evidence": {
+      "title": "Permanence Evidence",
+      "description": "Non-permanence risk assessment using T-BAR tool, buffer pool contribution calculation, and risk mitigation measures.",
+      "section_ids": [
+        "permanence"
+      ]
+    },
+    "ccb_evidence": {
+      "title": "CCB Evidence",
+      "description": "Community impact assessment, biodiversity impact assessment, stakeholder consultation records, and benefit-sharing plan (CCB projects only).",
+      "section_ids": [
+        "ccb"
+      ]
+    },
+    "sdg_evidence": {
+      "title": "SDG Evidence",
+      "description": "Mapping of project impacts to specific SDG targets, contribution quantification, and host country alignment documentation.",
+      "section_ids": [
+        "sdg-contributions"
+      ]
+    }
+  },
+  "section_mappings": [
+    {
+      "methodology": "VM0007",
+      "version": "v1-8",
+      "mappings": [
+        {
+          "methodology_section_id": "S-8",
+          "export_section_id": "project-description"
+        },
+        {
+          "methodology_section_id": "S-1",
+          "export_section_id": "applicability"
+        },
+        {
+          "methodology_section_id": "S-2",
+          "export_section_id": "project-boundary"
+        },
+        {
+          "methodology_section_id": "S-3",
+          "export_section_id": "baseline"
+        },
+        {
+          "methodology_section_id": "S-4",
+          "export_section_id": "additionality"
+        },
+        {
+          "methodology_section_id": "S-5",
+          "export_section_id": "quantification"
+        },
+        {
+          "methodology_section_id": "S-6",
+          "export_section_id": "monitoring"
+        },
+        {
+          "methodology_section_id": "S-5-3",
+          "export_section_id": "leakage"
+        }
+      ]
+    },
+    {
+      "methodology": "VM0047",
+      "version": "v1-0",
+      "mappings": [
+        {
+          "methodology_section_id": "S-2",
+          "export_section_id": "project-description"
+        },
+        {
+          "methodology_section_id": "S-4",
+          "export_section_id": "applicability"
+        },
+        {
+          "methodology_section_id": "S-5",
+          "export_section_id": "project-boundary"
+        },
+        {
+          "methodology_section_id": "S-6",
+          "export_section_id": "baseline"
+        },
+        {
+          "methodology_section_id": "S-7",
+          "export_section_id": "additionality"
+        },
+        {
+          "methodology_section_id": "S-8",
+          "export_section_id": "quantification"
+        },
+        {
+          "methodology_section_id": "S-8-3",
+          "export_section_id": "leakage"
+        },
+        {
+          "methodology_section_id": "S-9",
+          "export_section_id": "monitoring"
+        }
+      ]
+    }
+  ],
+  "disclaimers": {
+    "readiness": "This report is a readiness assessment prepared for informational purposes only. It does not constitute a validation opinion, verification opinion, or certification under the Verified Carbon Standard (VCS) or any other Verra program. No claim of conformance with VCS requirements shall be made until a validation or verification body (VVB) has issued a positive opinion following a full audit.",
+    "validation": "This draft has been prepared to support the validation process under the Verified Carbon Standard (VCS). It has not been independently verified by a validation or verification body (VVB) and does not represent a validation opinion. Final validation shall be confirmed by a VVB in accordance with the VCS Standard and relevant program rules.",
+    "verification": "This report has been prepared in connection with verification under the Verified Carbon Standard (VCS). Verification is subject to completion of a full audit by an accredited validation or verification body (VVB). No verified carbon units (VCUs) may be issued until a positive verification opinion has been issued."
+  }
+}

--- a/schemas/export-metadata.schema.json
+++ b/schemas/export-metadata.schema.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "sectionTaxonomyItem": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "title": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "description": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "export_order": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "parent_id": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "evidence_categories": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "id",
+        "title",
+        "description",
+        "required",
+        "export_order",
+        "evidence_categories"
+      ],
+      "type": "object"
+    },
+    "sectionMapping": {
+      "additionalProperties": false,
+      "properties": {
+        "methodology_section_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "export_section_id": {
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "methodology_section_id",
+        "export_section_id"
+      ],
+      "type": "object"
+    },
+    "methodologyMapping": {
+      "additionalProperties": false,
+      "properties": {
+        "methodology": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "version": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "mappings": {
+          "items": {
+            "$ref": "#/definitions/sectionMapping"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "required": [
+        "methodology",
+        "version",
+        "mappings"
+      ],
+      "type": "object"
+    },
+    "evidenceCategory": {
+      "additionalProperties": false,
+      "properties": {
+        "title": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "description": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "section_ids": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "title",
+        "description"
+      ],
+      "type": "object"
+    }
+  },
+  "properties": {
+    "standard": {
+      "type": "string",
+      "enum": [
+        "Verra",
+        "Gold Standard"
+      ]
+    },
+    "metadata_version": {
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "type": "string"
+    },
+    "last_updated": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "section_taxonomy": {
+      "items": {
+        "$ref": "#/definitions/sectionTaxonomyItem"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "required_export_sections": {
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "evidence_categories": {
+      "additionalProperties": {
+        "$ref": "#/definitions/evidenceCategory"
+      },
+      "minProperties": 1,
+      "type": "object"
+    },
+    "section_mappings": {
+      "items": {
+        "$ref": "#/definitions/methodologyMapping"
+      },
+      "type": "array"
+    },
+    "disclaimers": {
+      "additionalProperties": false,
+      "properties": {
+        "readiness": {
+          "type": "string"
+        },
+        "validation": {
+          "type": "string"
+        },
+        "verification": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "readiness"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "standard",
+    "metadata_version",
+    "last_updated",
+    "section_taxonomy",
+    "required_export_sections",
+    "evidence_categories",
+    "disclaimers"
+  ],
+  "type": "object"
+}

--- a/scripts/grade-method.js
+++ b/scripts/grade-method.js
@@ -39,7 +39,7 @@ function isGradeA(methodDir) {
   const methodologyRef = meta.references?.tools?.[0]?.doc ||
     `${meta.standard}/${meta.methodology.replace(/ .*/, '')}@${meta.version}`;
 
-  // 0. META must declare Grade A readiness
+  // 0. META must declare Source-Audited readiness
   if (meta.artifact_quality_standard?.adoption_status !== 'grade_a') {
     errors.push(`META adoption_status is "${meta.artifact_quality_standard?.adoption_status}", expected "grade_a"`);
   }
@@ -62,7 +62,7 @@ function isGradeA(methodDir) {
 
   // 2. No draft rules
   if (draftRules.length > 0) {
-    errors.push(`${draftRules.length} draft_unverified rules exist (require 0 for Grade A)`);
+    errors.push(`${draftRules.length} draft_unverified rules exist (require 0 for Source-Audited)`);
   }
 
   // 2a. No active external_unencoded deps
@@ -137,9 +137,9 @@ if (args.length > 0) {
     const dir = path.resolve(ROOT, arg);
     const result = isGradeA(dir);
     if (result.gradeA) {
-      console.log(`${path.relative(ROOT, dir)}: Grade A`);
+      console.log(`${path.relative(ROOT, dir)}: Source-Audited`);
     } else {
-      console.log(`${path.relative(ROOT, dir)}: NOT Grade A`);
+      console.log(`${path.relative(ROOT, dir)}: NOT Source-Audited`);
       for (const err of result.errors) {
         console.error(`  - ${err}`);
       }

--- a/scripts/pack-methodologies.sh
+++ b/scripts/pack-methodologies.sh
@@ -36,6 +36,8 @@ rsync -a --prune-empty-dirs \
   --include='sections.json' \
   --include='rich.json' \
   --include='*.rich.json' \
+  --include='_export/' \
+  --include='_export/export-metadata.json' \
   --exclude='*' \
   methodologies/ "$TMP/methodologies-pack/methodologies/"
 

--- a/tests/export-metadata.test.js
+++ b/tests/export-metadata.test.js
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, filePath), 'utf8'));
+}
+
+function main() {
+  // 1. Verify schema exists and is valid JSON
+  const schema = readJson('schemas/export-metadata.schema.json');
+  assert.ok(schema.$schema, 'schema missing $schema');
+  assert.ok(schema.required.includes('standard'), 'schema missing standard in required');
+  assert.ok(schema.required.includes('section_taxonomy'), 'schema missing section_taxonomy in required');
+  assert.ok(schema.required.includes('evidence_categories'), 'schema missing evidence_categories in required');
+  assert.ok(schema.required.includes('disclaimers'), 'schema missing disclaimers in required');
+
+  // 2. Verra export metadata
+  const verraExport = readJson('methodologies/Verra/_export/export-metadata.json');
+  assert.strictEqual(verraExport.standard, 'Verra', 'Verra metadata missing standard');
+  assert.strictEqual(verraExport.metadata_version, '1.0.0', 'Verra metadata_version mismatch');
+
+  // 2a. Section taxonomy completeness
+  assert.ok(Array.isArray(verraExport.section_taxonomy), 'Verra section_taxonomy not an array');
+  const verraSectionIds = verraExport.section_taxonomy.map(s => s.id);
+  const verraSectionIdSet = new Set(verraSectionIds);
+  assert.strictEqual(verraSectionIds.length, verraSectionIdSet.size, 'Verra section_taxonomy has duplicate ids');
+  for (const section of verraExport.section_taxonomy) {
+    assert.ok(section.id, 'Verra section missing id');
+    assert.ok(section.title, `Verra section ${section.id} missing title`);
+    assert.ok(section.description, `Verra section ${section.id} missing description`);
+    assert.ok(typeof section.required === 'boolean', `Verra section ${section.id} required must be boolean`);
+    assert.ok(Number.isInteger(section.export_order), `Verra section ${section.id} export_order must be integer`);
+    assert.ok(section.export_order >= 1, `Verra section ${section.id} export_order must be >= 1`);
+    assert.ok(Array.isArray(section.evidence_categories), `Verra section ${section.id} missing evidence_categories`);
+    for (const cat of section.evidence_categories) {
+      assert.ok(verraExport.evidence_categories[cat], `Verra section ${section.id} references unknown evidence category '${cat}'`);
+    }
+  }
+
+  // 2b. Required export sections exist in taxonomy
+  for (const secId of verraExport.required_export_sections) {
+    assert.ok(verraSectionIdSet.has(secId), `Verra required_export_section '${secId}' not found in section_taxonomy`);
+  }
+
+  // 2c. Evidence categories completeness
+  const verraRequiredCats = ['project_description', 'applicability_evidence', 'boundary_delineation',
+    'baseline_evidence', 'additionality_evidence', 'quantification_evidence',
+    'monitoring_evidence', 'leakage_evidence', 'permanence_evidence'];
+  for (const cat of verraRequiredCats) {
+    assert.ok(verraExport.evidence_categories[cat], `Verra missing required evidence category '${cat}'`);
+    assert.ok(verraExport.evidence_categories[cat].title, `Verra evidence category '${cat}' missing title`);
+    assert.ok(verraExport.evidence_categories[cat].description, `Verra evidence category '${cat}' missing description`);
+  }
+
+  // 2d. Section mappings
+  assert.ok(Array.isArray(verraExport.section_mappings), 'Verra missing section_mappings');
+  const verraMethodologies = new Set(verraExport.section_mappings.map(m => m.methodology));
+  assert.ok(verraMethodologies.has('VM0007'), 'Verra section_mappings missing VM0007');
+  assert.ok(verraMethodologies.has('VM0047'), 'Verra section_mappings missing VM0047');
+  for (const mapping of verraExport.section_mappings) {
+    assert.ok(mapping.methodology, 'Verra mapping missing methodology name');
+    assert.ok(mapping.version, `Verra mapping ${mapping.methodology} missing version`);
+    assert.ok(Array.isArray(mapping.mappings), `Verra mapping ${mapping.methodology} missing mappings array`);
+    for (const m of mapping.mappings) {
+      assert.ok(m.methodology_section_id, `Verra mapping ${mapping.methodology} missing methodology_section_id`);
+      assert.ok(m.export_section_id, `Verra mapping ${mapping.methodology} missing export_section_id`);
+      assert.ok(verraSectionIdSet.has(m.export_section_id),
+        `Verra mapping ${mapping.methodology} references unknown export section '${m.export_section_id}'`);
+    }
+  }
+
+  // 2e. Disclaimers
+  assert.ok(verraExport.disclaimers, 'Verra missing disclaimers');
+  assert.ok(verraExport.disclaimers.readiness, 'Verra missing readiness disclaimer');
+  assert.ok(verraExport.disclaimers.readiness.length > 50, 'Verra readiness disclaimer too short');
+  assert.ok(verraExport.disclaimers.validation, 'Verra missing validation disclaimer');
+  assert.ok(verraExport.disclaimers.verification, 'Verra missing verification disclaimer');
+
+  // 3. Gold Standard export metadata
+  const gsExport = readJson('methodologies/GoldStandard/_export/export-metadata.json');
+  assert.strictEqual(gsExport.standard, 'Gold Standard', 'GS metadata missing standard');
+  assert.strictEqual(gsExport.metadata_version, '1.0.0', 'GS metadata_version mismatch');
+
+  // 3a. Section taxonomy completeness
+  assert.ok(Array.isArray(gsExport.section_taxonomy), 'GS section_taxonomy not an array');
+  const gsSectionIds = gsExport.section_taxonomy.map(s => s.id);
+  const gsSectionIdSet = new Set(gsSectionIds);
+  assert.strictEqual(gsSectionIds.length, gsSectionIdSet.size, 'GS section_taxonomy has duplicate ids');
+  for (const section of gsExport.section_taxonomy) {
+    assert.ok(section.id, 'GS section missing id');
+    assert.ok(section.title, `GS section ${section.id} missing title`);
+    assert.ok(section.description, `GS section ${section.id} missing description`);
+    assert.ok(typeof section.required === 'boolean', `GS section ${section.id} required must be boolean`);
+    assert.ok(Number.isInteger(section.export_order), `GS section ${section.id} export_order must be integer`);
+    assert.ok(section.export_order >= 1, `GS section ${section.id} export_order must be >= 1`);
+    assert.ok(Array.isArray(section.evidence_categories), `GS section ${section.id} missing evidence_categories`);
+    for (const cat of section.evidence_categories) {
+      assert.ok(gsExport.evidence_categories[cat], `GS section ${section.id} references unknown evidence category '${cat}'`);
+    }
+  }
+
+  // 3b. Required export sections exist in taxonomy
+  for (const secId of gsExport.required_export_sections) {
+    assert.ok(gsSectionIdSet.has(secId), `GS required_export_section '${secId}' not found in section_taxonomy`);
+  }
+
+  // 3c. Evidence categories completeness
+  const gsRequiredCats = ['project_design_documentation', 'applicability_evidence',
+    'additionality_evidence', 'eligibility_evidence', 'baseline_evidence',
+    'monitoring_evidence', 'quantification_evidence', 'safeguards_evidence',
+    'stakeholder_evidence', 'sdg_evidence', 'uncertainty_evidence'];
+  for (const cat of gsRequiredCats) {
+    assert.ok(gsExport.evidence_categories[cat], `GS missing required evidence category '${cat}'`);
+    assert.ok(gsExport.evidence_categories[cat].title, `GS evidence category '${cat}' missing title`);
+    assert.ok(gsExport.evidence_categories[cat].description, `GS evidence category '${cat}' missing description`);
+  }
+
+  // 3d. Section mappings
+  assert.ok(Array.isArray(gsExport.section_mappings), 'GS missing section_mappings');
+  const gsMethodologies = new Set(gsExport.section_mappings.map(m => m.methodology));
+  assert.ok(gsMethodologies.has('GS-00XX'), 'GS section_mappings missing GS-00XX');
+  for (const mapping of gsExport.section_mappings) {
+    assert.ok(mapping.methodology, 'GS mapping missing methodology name');
+    assert.ok(mapping.version, `GS mapping ${mapping.methodology} missing version`);
+    assert.ok(Array.isArray(mapping.mappings), `GS mapping ${mapping.methodology} missing mappings array`);
+    for (const m of mapping.mappings) {
+      assert.ok(m.methodology_section_id, `GS mapping ${mapping.methodology} missing methodology_section_id`);
+      assert.ok(m.export_section_id, `GS mapping ${mapping.methodology} missing export_section_id`);
+      assert.ok(gsSectionIdSet.has(m.export_section_id),
+        `GS mapping ${mapping.methodology} references unknown export section '${m.export_section_id}'`);
+    }
+  }
+
+  // 3e. Disclaimers
+  assert.ok(gsExport.disclaimers, 'GS missing disclaimers');
+  assert.ok(gsExport.disclaimers.readiness, 'GS missing readiness disclaimer');
+  assert.ok(gsExport.disclaimers.readiness.length > 50, 'GS readiness disclaimer too short');
+  assert.ok(gsExport.disclaimers.validation, 'GS missing validation disclaimer');
+  assert.ok(gsExport.disclaimers.verification, 'GS missing verification disclaimer');
+
+  // 4. Cross-cut: verify exports referenced from META.json
+  const verraMeta = readJson('methodologies/Verra/AFOLU/VM0007/v1-8/META.json');
+  assert.ok(verraMeta.export, 'VM0007 META missing export field');
+  assert.strictEqual(verraMeta.export.metadata_version, '1.0.0', 'VM0007 export metadata_version mismatch');
+  assert.ok(verraMeta.export.path, 'VM0007 export path missing');
+
+  const vm0047Meta = readJson('methodologies/Verra/AFOLU/VM0047/v1-0/META.json');
+  assert.ok(vm0047Meta.export, 'VM0047 META missing export field');
+  assert.strictEqual(vm0047Meta.export.metadata_version, '1.0.0', 'VM0047 export metadata_version mismatch');
+
+  const gsMeta = readJson('methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json');
+  assert.ok(gsMeta.export, 'GS META missing export field');
+  assert.strictEqual(gsMeta.export.metadata_version, '1.0.0', 'GS export metadata_version mismatch');
+
+  // 5. Section IDs referenced in mappings match actual methodology sections
+  const verraSectionsVm0007 = readJson('methodologies/Verra/AFOLU/VM0007/v1-8/sections.json').sections;
+  const verraSectionIdsVm0007 = new Set(verraSectionsVm0007.map(s => s.id));
+  const vm0007Mapping = verraExport.section_mappings.find(m => m.methodology === 'VM0007');
+  for (const m of vm0007Mapping.mappings) {
+    assert.ok(verraSectionIdsVm0007.has(m.methodology_section_id),
+      `VM0007 mapping references non-existent methodology section '${m.methodology_section_id}'`);
+  }
+
+  const verraSectionsVm0047 = readJson('methodologies/Verra/AFOLU/VM0047/v1-0/sections.json').sections;
+  const verraSectionIdsVm0047 = new Set(verraSectionsVm0047.map(s => s.id));
+  const vm0047Mapping = verraExport.section_mappings.find(m => m.methodology === 'VM0047');
+  for (const m of vm0047Mapping.mappings) {
+    assert.ok(verraSectionIdsVm0047.has(m.methodology_section_id),
+      `VM0047 mapping references non-existent methodology section '${m.methodology_section_id}'`);
+  }
+
+  const gsSections = readJson('methodologies/GoldStandard/LUF/GS-00XX/v1-0/sections.json').sections;
+  const gsSectionIdsActual = new Set(gsSections.map(s => s.id));
+  const gsMapping = gsExport.section_mappings.find(m => m.methodology === 'GS-00XX');
+  for (const m of gsMapping.mappings) {
+    assert.ok(gsSectionIdsActual.has(m.methodology_section_id),
+      `GS-00XX mapping references non-existent methodology section '${m.methodology_section_id}'`);
+  }
+
+  console.log('ok');
+}
+
+main();

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -26,6 +26,7 @@ const tests = [
   'tests/verra-vm0007-draft-truthfulness.test.js',
   'tests/pr-accept-harness.test.js',
   'tests/rc-s7-ingestion-hardening-proof.test.js',
+  'tests/export-metadata.test.js',
 ];
 
 function main() {

--- a/tests/verra-method-grade.test.js
+++ b/tests/verra-method-grade.test.js
@@ -14,34 +14,34 @@ function main() {
   const VM0007_DIR = path.join(ROOT, 'methodologies', 'Verra', 'AFOLU', 'VM0007', 'v1-8');
   const VM0047_DIR = path.join(ROOT, 'methodologies', 'Verra', 'AFOLU', 'VM0047', 'v1-0');
 
-  // 1. VM0047 is Grade A (computed from canonical artifacts)
+  // 1. VM0047 is Source-Audited (computed from canonical artifacts)
   const vm0047 = require('../scripts/grade-method').isGradeA(VM0047_DIR);
-  assert.equal(vm0047.gradeA, true, 'VM0047 must be Grade A after all 11 rules promoted and dependencies resolved');
-  assert.equal(vm0047.errors.length, 0, 'VM0047 must have 0 Grade A errors');
+  assert.equal(vm0047.gradeA, true, 'VM0047 must be Source-Audited after all 11 rules promoted and dependencies resolved');
+  assert.equal(vm0047.errors.length, 0, 'VM0047 must have 0 Source-Audited errors');
 
-  // 2. VM0007 META confirms S-grade
+  // 2. VM0007 META confirms Source-Audited (grade_a legacy alias)
   const vm0007Meta = readJSON(path.join(VM0007_DIR, 'META.json'));
-  assert.equal(vm0007Meta.artifact_status?.rules, 'source_audited', 'VM0007 rules must be source_audited at S-grade');
-  assert.equal(vm0007Meta.methodology_linked_review_ready, true, 'VM0007 must be review-ready at S-grade');
-  assert.equal(vm0007Meta.artifact_quality_standard?.adoption_status, 'grade_a', 'VM0007 META adoption_status must be grade_a');
+  assert.equal(vm0007Meta.artifact_status?.rules, 'source_audited', 'VM0007 rules must be source_audited at Source-Audited');
+  assert.equal(vm0007Meta.methodology_linked_review_ready, true, 'VM0007 must be review-ready at Source-Audited');
+  assert.equal(vm0007Meta.artifact_quality_standard?.adoption_status, 'grade_a', 'VM0007 META adoption_status must be grade_a (legacy/internal alias for Source-Audited)');
 
   // 3. VM0047 META checks
   const vm0047Meta = readJSON(path.join(VM0047_DIR, 'META.json'));
   assert.equal(vm0047Meta.methodology_linked_review_ready, true, 'VM0047 META methodology_linked_review_ready must be true');
   assert.equal(vm0047Meta.artifact_status?.rules, 'source_audited', 'VM0047 META rules status must be source_audited');
-  assert.equal(vm0047Meta.artifact_quality_standard?.adoption_status, 'grade_a', 'VM0047 META adoption_status must be grade_a');
+  assert.equal(vm0047Meta.artifact_quality_standard?.adoption_status, 'grade_a', 'VM0047 META adoption_status must be grade_a (legacy/internal alias for Source-Audited)');
 
   // 4. VM0007 has no remaining blocked external dependencies
   const vm0007Blocked = readJSON(path.join(VM0007_DIR, 'blocked-external-dependencies.json'));
-  assert.equal(vm0007Blocked.blocked_rule_count, 0, 'VM0007 must have 0 blocked rules at S-grade');
-  assert.equal(vm0007Blocked.blocked_rules.length, 0, 'VM0007 must have 0 blocked rule entries at S-grade');
+  assert.equal(vm0007Blocked.blocked_rule_count, 0, 'VM0007 must have 0 blocked rules at Source-Audited');
+  assert.equal(vm0007Blocked.blocked_rules.length, 0, 'VM0007 must have 0 blocked rule entries at Source-Audited');
 
   // 5. All 58 VM0007 rules are source_audited
   const vm0007Rules = readJSON(path.join(VM0007_DIR, 'rules.json')).rules;
-  const sourceAudited = vm0007Rules.filter((r) => r.quality_status === 'source_audited');
-  const draftRules = vm0007Rules.filter((r) => r.quality_status === 'draft_unverified');
-  assert.equal(sourceAudited.length, 58, 'VM0007 must have exactly 58 source_audited rules at S-grade');
-  assert.equal(draftRules.length, 0, 'VM0007 must have 0 draft_unverified rules at S-grade');
+  const vm0007SourceAudited = vm0007Rules.filter((r) => r.quality_status === 'source_audited');
+  const vm0007DraftRules = vm0007Rules.filter((r) => r.quality_status === 'draft_unverified');
+  assert.equal(vm0007SourceAudited.length, 58, 'VM0007 must have exactly 58 source_audited rules at Source-Audited');
+  assert.equal(vm0007DraftRules.length, 0, 'VM0007 must have 0 draft_unverified rules at Source-Audited');
 
   // 6. T-SIG is not an active VM0047 blocker
   const inv = readJSON(path.join(VM0047_DIR, 'blocked-external-dependencies.json'));

--- a/tests/verra-vm0047-truthfulness.test.js
+++ b/tests/verra-vm0047-truthfulness.test.js
@@ -22,9 +22,9 @@ function main() {
   // --- Base artifact status ---
   assert.equal(meta.artifact_status?.source_pdf, 'verified', 'VM0047 source PDF must be verified');
   assert.equal(meta.artifact_status?.sections, 'source_audited', 'VM0047 sections must be source_audited from TOC');
-  assert.equal(meta.artifact_status?.rules, 'source_audited', 'VM0047 rules must be source_audited at Grade A');
+  assert.equal(meta.artifact_status?.rules, 'source_audited', 'VM0047 rules must be source_audited at Source-Audited');
   assert.equal(meta.artifact_quality_standard?.version, 'review_contract_v1', 'VM0047 should opt into review_contract_v1');
-  assert.equal(meta.methodology_linked_review_ready, true, 'VM0047 must be methodology-linked-review-ready at Grade A');
+  assert.equal(meta.methodology_linked_review_ready, true, 'VM0047 must be methodology-linked-review-ready at Source-Audited');
   assert.ok(Array.isArray(meta.methodology_linked_review_blockers), 'VM0047 must have a blockers array');
 
   // --- Exact section count ---
@@ -34,8 +34,8 @@ function main() {
   assert.equal(rules.length, 11, 'VM0047 must have exactly 11 rules');
   const sourceAuditedRules = rules.filter((rule) => rule.quality_status === 'source_audited');
   const draftRules = rules.filter((rule) => rule.quality_status === 'draft_unverified');
-  assert.equal(sourceAuditedRules.length, 11, 'VM0047 must have exactly 11 source-audited rules at Grade A');
-  assert.equal(draftRules.length, 0, 'VM0047 must have 0 draft_unverified rules at Grade A');
+  assert.equal(sourceAuditedRules.length, 11, 'VM0047 must have exactly 11 source-audited rules at Source-Audited');
+  assert.equal(draftRules.length, 0, 'VM0047 must have 0 draft_unverified rules at Source-Audited');
 
   // --- Rich/lean parity across all rules ---
   for (const rule of rules) {
@@ -68,7 +68,7 @@ function main() {
     }
   }
 
-  assert.equal(draftRules.length, 0, 'VM0047 must have 0 draft rules at Grade A with source-backed rules');
+  assert.equal(draftRules.length, 0, 'VM0047 must have 0 draft rules at Source-Audited with source-backed rules');
 
   // --- External dependency declarations ---
   const ruleTools = new Set();
@@ -81,7 +81,7 @@ function main() {
   const externalRefs = new Map(
     (meta.external_dependencies?.methodology_and_tool_refs || []).map((entry) => [entry.id, entry])
   );
-  assert.ok(['external_unencoded', 'historical_non_blocking'].includes(meta.external_dependencies?.status), 'VM0047 external dependency status must be external_unencoded or historical_non_blocking at Grade A');
+  assert.ok(['external_unencoded', 'historical_non_blocking'].includes(meta.external_dependencies?.status), 'VM0047 external dependency status must be external_unencoded or historical_non_blocking at Source-Audited');
   for (const toolId of ruleTools) {
     const entry = externalRefs.get(toolId);
     assert.ok(entry, `VM0047 external dependency ${toolId} must be declared in META.json`);
@@ -92,8 +92,8 @@ function main() {
   // --- Blocker inventory ---
   const inventory = readJSON(path.join(METHOD_DIR, 'blocked-external-dependencies.json'));
   assert.equal(inventory.methodology, 'Verra/VM0047@v1-0', 'inventory methodology must match');
-  assert.equal(inventory.blocked_rule_count, 0, 'inventory must report 0 blocked rules at Grade A');
-  assert.equal(inventory.blocked_rules.length, 0, 'inventory must contain 0 blocked rule entries at Grade A');
+  assert.equal(inventory.blocked_rule_count, 0, 'inventory must report 0 blocked rules at Source-Audited');
+  assert.equal(inventory.blocked_rules.length, 0, 'inventory must contain 0 blocked rule entries at Source-Audited');
 
   // --- Provenance ---
   assert.equal(meta.provenance?.source_pdfs?.[0]?.sha256, '987f86d4e7f8aa939875dbf6a1376287444531954f7573b3b46fe0e07919ded6', 'VM0047 source PDF hash must match');


### PR DESCRIPTION
## WHAT

Create canonical standard-specific export metadata for Verra VCS and Gold Standard in `article6-methodologies` to enable Phase 7 composers in `app.article6`.

This PR establishes the **upstream metadata contract** that standard-specific report composers consume. The app no longer needs to hardcode section taxonomies, evidence requirements, or disclaimer language — it reads them from canonical JSON instances.

### Files created

| File | Purpose |
|------|---------|
| `schemas/export-metadata.schema.json` | Shared JSON Schema (draft-07) validating both standard instances |
| `methodologies/Verra/_export/export-metadata.json` | Verra VCS: 11-section taxonomy, 9 required export sections, 11 evidence categories, VM0007 + VM0047 mappings |
| `methodologies/GoldStandard/_export/export-metadata.json` | Gold Standard GS4GG: 9-section taxonomy, 9 required export sections, 11 evidence categories, GS-00XX mappings |
| `docs/roadmaps/standard-specific-export-metadata/app-consumption-contract.md` | App-facing contract documenting every field, type, and consumption pattern |
| `tests/export-metadata.test.js` | Validation tests for section ID integrity, evidence completeness, mapping accuracy, disclaimer readiness, META link |

### Files modified

| File | Change |
|------|--------|
| `methodologies/Verra/AFOLU/VM0007/v1-8/META.json` | Added `export` field linking to Verra export metadata |
| `methodologies/Verra/AFOLU/VM0047/v1-0/META.json` | Added `export` field linking to Verra export metadata |
| `methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json` | Added `export` field linking to GS export metadata |
| `scripts/pack-methodologies.sh` | Added `--include='_export/'` and `--include='_export/export-metadata.json'` to rsync |
| `tests/run-tests.js` | Added `tests/export-metadata.test.js` to test runner |

## WHY

- Phase 7 composers in `app.article6` are blocked until canonical metadata exists.
- Without this, the app must either hardcode standard-specific logic (fragile, duplicated) or produce generic outputs that neither standard accepts.
- Encoded metadata ensures standard-specific reports are truthful, compliant, and safely generated.
- Provides a **single source of truth (SSOT)** for the app to consume.

## CHANGES

1. **Shared schema** (`schemas/export-metadata.schema.json`) — Defines `section_taxonomy`, `required_export_sections`, `evidence_categories`, `section_mappings`, `disclaimers` as top-level keys with full type constraints.

2. **Verra export metadata** — 11 canonical sections (Project Description → SDG Contributions), 9 required for every VCS export, 11 evidence categories (project_description → sdg_evidence), section mappings for both VM0007 and VM0047, and 3 disclaimer variants (readiness, validation, verification) using Verra-approved language.

3. **Gold Standard export metadata** — 9 canonical sections (Project Design → Uncertainty Assessment), all 9 required for GS4GG compliance, 11 evidence categories, section mappings for GS-00XX, and GS-approved disclaimer language.

4. **META links** — Every active Verra and GS methodology now carries `META.export = { metadata_version, path }` for app feature detection.

5. **Pack integration** — `scripts/pack-methodologies.sh` includes `_export/export-metadata.json` so published methodology packs carry the metadata.

6. **Tests** (`tests/export-metadata.test.js`) validate:
   - Section IDs exist and are unique per standard
   - Required export sections reference valid taxonomy entries
   - Evidence categories are complete with titles and descriptions
   - Section mappings reference only existing methodology section IDs (cross-validated against actual `sections.json`)
   - Disclaimers are present and substantive (length > 50 chars)
   - META.json `export` field is present with correct metadata_version
   - No duplicate or orphan references

## VALIDATION

All CI checks pass:

```text
$ node tests/export-metadata.test.js
ok

$ npx ajv-cli validate -s schemas/export-metadata.schema.json -d methodologies/Verra/_export/export-metadata.json --strict=false
methodologies/Verra/_export/export-metadata.json valid

$ npx ajv-cli validate -s schemas/export-metadata.schema.json -d methodologies/GoldStandard/_export/export-metadata.json --strict=false
methodologies/GoldStandard/_export/export-metadata.json valid

$ npx ajv-cli validate -s schemas/META.schema.json -d methodologies/Verra/AFOLU/VM0007/v1-8/META.json
valid
$ npx ajv-cli validate -s schemas/META.schema.json -d methodologies/Verra/AFOLU/VM0047/v1-0/META.json
valid
$ npx ajv-cli validate -s schemas/META.schema.json -d methodologies/GoldStandard/LUF/GS-00XX/v1-0/META.json
valid
```

## ACCEPTANCE

- `node tests/export-metadata.test.js` must pass
- Schema validation via `validate-json` workflow must pass for all JSON files
- Roadmap phase-status.json shows SEM-S1 through SEM-S5 as "completed"
- No existing methodology artifacts (`sections.json`, `rules.json`, `rules.rich.json`) are modified
- Agriculture and Forestry fixture tests must remain green

Signed-off-by: Fred E <fredilly@article6.org>