### PR TITLE
feat: add review-grade evidence intelligence roadmap, standard, and taxonomy

### DIFF
--- a/docs/roadmaps/review-grade-evidence-intelligence/ROADMAP.md
+++ b/docs/roadmaps/review-grade-evidence-intelligence/ROADMAP.md
@@ -1,0 +1,137 @@
+# Review-Grade Evidence Intelligence
+
+Status is sourced from `docs/roadmaps/review-grade-evidence-intelligence/phase-status.json`; docs must not drift.
+
+**Ownership boundary**: `article6-methodologies` defines the Review-Grade methodology pack standard, the expected evidence taxonomy, and the rule-to-evidence mapping schema. `app.article6` consumes these artifacts to drive evidence pickers, review panels, and export composers — it must not invent evidence categories or pack quality tiers.
+
+## Why this matters
+
+The Source-Audited standard guarantees that every rule has a verifiable source span and no `draft_unverified` gaps. However, it does not describe *what evidence a reviewer must examine* to verify each rule. Without structured evidence metadata:
+
+- The app cannot show reviewers which document types are expected per rule
+- Evidence pickers must rely on hardcoded heuristics that drift across methods
+- Export composers cannot produce standard-compliant evidence tables
+- Deterministic linking between rules and uploaded evidence is impossible
+
+This roadmap formalizes the Review-Grade pack standard — the next quality tier above Source-Audited — and delivers the evidence taxonomy and mapping schema the app needs for deterministic evidence linking.
+
+## How this fits with existing roadmaps
+
+| Roadmap | Relationship |
+|---------|-------------|
+| `traceable-rule-review-mvp` | Phase 2 seeded `requirement_coverage.expected_evidence` as an optional field. This roadmap makes it mandatory at Review-Grade and formalizes the taxonomy. |
+| `standard-specific-export-metadata` | Defines standard-level evidence categories (Verra, Gold Standard). This roadmap defines rule-level expected evidence types that feed into those categories. |
+| `requirement-coverage-support` | RC-S6 added optional `expected_evidence` metadata. This roadmap hardens that into a Review-Grade requirement. |
+
+## Scope for this roadmap
+
+- Define the Review-Grade Method Pack Standard as a formal quality tier above Source-Audited
+- Publish the expected evidence taxonomy: machine-readable categories every rule can reference
+- Create the rule-to-evidence mapping JSON Schema for `rules.rich.json`
+- Populate expected evidence metadata across target method packs
+- Define the app consumption contract for evidence intelligence fields
+- Do not change the existing rule schema or source-audited artifacts without review
+- Do not build app UI, evidence upload, or review workflow
+
+## Phases
+
+### RGEI-S1 — Review-Grade Method Pack Standard
+
+Objective: Formalize the Review-Grade quality standard as a documented, machine-verifiable tier.
+
+- Publish `docs/standards/review-grade-method-pack-standard.md`
+- Define the Review-Grade adoption criteria relative to Source-Audited
+- Add the standard's machine-readable fields (`adoption_status: "review_grade"`)
+- Document transition path from Source-Audited to Review-Grade
+- Define CI verification gates
+
+Acceptance:
+- Standard document published and reviewed
+- Schema permits `adoption_status: "review_grade"` as a valid value
+- Transition path documented with examples
+
+### RGEI-S2 — Expected Evidence Taxonomy
+
+Objective: Publish a canonical taxonomy of evidence types that methodology rules can reference.
+
+- Define top-level evidence categories (document, geospatial, calculation, field measurement, attestation)
+- Define evidence kinds per category (mandatory, optional, conditional)
+- Define evidence attributes (format, source requirement, temporal scope)
+- Publish taxonomy in `docs/standards/expected-evidence-taxonomy.md`
+- Publish JSON Schema in `schemas/evidence-taxonomy.schema.json`
+
+Acceptance:
+- Taxonomy document published with full category definitions
+- JSON Schema validates taxonomy instances
+- Every category has a clear definition, example, and usage guidance
+
+### RGEI-S3 — Rule-to-Evidence Mapping Schema
+
+Objective: Create the JSON Schema for expected evidence metadata in `rules.rich.json`.
+
+- Define `requirement_coverage.expected_evidence[]` schema
+  - `evidence_type_id`: references the taxonomy
+  - `evidence_kind`: mandatory, optional, conditional
+  - `evidence_condition`: expression when `evidence_kind` is conditional
+  - `description`: human-readable guidance
+  - `format`: pdf, xlsx, geotiff, csv, etc.
+- Define `requirement_coverage.requirement_kind` schema
+  - `human-judgment-required`, `calculable`, `document-check`
+- Publish schema in `schemas/rule-evidence-mapping.schema.json`
+- Update existing `schemas/rules.rich.schema.json` if reviewed
+
+Acceptance:
+- Schema validates expected_evidence entries
+- Schema enforced in CI for Review-Grade methods
+
+### RGEI-S4 — Methodology Pack Integration
+
+Objective: Integrate evidence metadata into methodology pack artifacts.
+
+- Populate `requirement_coverage.expected_evidence` across target methods
+- Ensure pack scripts include evidence metadata
+- Verify deterministic generation with evidence fields populated
+- Add CI checks that Review-Grade methods have complete evidence metadata
+
+Acceptance:
+- Target methods have populated expected_evidence per rule
+- Pack tarballs include complete evidence metadata
+- CI fails if a Review-Grade method is missing required evidence metadata
+
+### RGEI-S5 — App Consumption Contract
+
+Objective: Define the exact JSON fields the app reads for evidence intelligence.
+
+- Document the app-facing contract in `docs/roadmaps/review-grade-evidence-intelligence/app-consumption-contract.md`
+- Pin contract version in META.json (`export.evidence_intelligence_version`)
+- Every field needed by the app has a corresponding source in `rules.rich.json`
+- CI validates contract compliance
+
+Acceptance:
+- Contract document published with field types, examples, and optionality
+- META.json version tag present for Review-Grade methods
+- No field in the contract lacks a populated source
+
+### RGEI-S6 — Pilot Method Packs at Review-Grade
+
+Objective: Promote at least one method pack to Review-Grade status for pilot consumption.
+
+- Select target method (e.g., AR-ACM0003 v02-0 or VM0007 v1-8)
+- Populate expected_evidence for every rule
+- Set `adoption_status: "review_grade"` in META.json
+- Verify all CI gates pass
+- Publish updated pack
+
+Acceptance:
+- At least one method pack at Review-Grade
+- CI green across all gates
+- App can consume evidence metadata from the pack
+
+## Delivery constraints
+
+- Do not build app UI, evidence upload, or review workflow here
+- Do not change existing rule schema or source-audited artifacts without review
+- Do not break existing Source-Audited methods during transition
+- All evidence metadata must be deterministic (same input → same bytes)
+- Evidence taxonomy must be extensible: adding a new type must not break existing mappings
+- Ownership boundary is strict: methodologies repo defines semantics; app repo consumes them

--- a/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
+++ b/docs/roadmaps/review-grade-evidence-intelligence/phase-status.json
@@ -1,0 +1,42 @@
+{
+  "goal": "Formalize the Review-Grade method pack standard, expected evidence taxonomy, and rule-to-evidence mapping schema so app.article6 can drive deterministic evidence linking without hardcoded heuristics.",
+  "last_updated_at": "2026-05-19T00:00:00Z",
+  "notes": [
+    "RGEI-S1 through RGEI-S6 defined but not yet started.",
+    "Builds on RC-S6 (optional expected_evidence) and traceable-rule-review-mvp Phase 2 (evidence contract seeding).",
+    "Review-Grade is a formal superset of Source-Audited: all Source-Audited requirements plus complete expected evidence metadata.",
+    "No methodology packs are at Review-Grade until RGEI-S6 is delivered."
+  ],
+  "phases": [
+    {
+      "id": "rgei-s1-review-grade-standard",
+      "name": "Review-Grade Method Pack Standard",
+      "status": "not_started"
+    },
+    {
+      "id": "rgei-s2-evidence-taxonomy",
+      "name": "Expected Evidence Taxonomy",
+      "status": "not_started"
+    },
+    {
+      "id": "rgei-s3-rule-evidence-mapping-schema",
+      "name": "Rule-to-Evidence Mapping Schema",
+      "status": "not_started"
+    },
+    {
+      "id": "rgei-s4-pack-integration",
+      "name": "Methodology Pack Integration",
+      "status": "not_started"
+    },
+    {
+      "id": "rgei-s5-app-consumption-contract",
+      "name": "App Consumption Contract",
+      "status": "not_started"
+    },
+    {
+      "id": "rgei-s6-pilot-method-packs",
+      "name": "Pilot Method Packs at Review-Grade",
+      "status": "not_started"
+    }
+  ]
+}

--- a/docs/standards/expected-evidence-taxonomy.md
+++ b/docs/standards/expected-evidence-taxonomy.md
@@ -1,0 +1,316 @@
+# Expected Evidence Taxonomy
+
+This document defines the canonical taxonomy of evidence types that methodology rules can reference in `requirement_coverage.expected_evidence`. Every `evidence_type_id` used in a Review-Grade method pack must resolve to an entry defined here.
+
+## Taxonomy structure
+
+The taxonomy is a flat list of evidence type entries, each with:
+- `id`: machine-readable identifier (e.g., `monitoring_report`)
+- `display_name`: human-readable label (e.g., "Monitoring Report")
+- `category`: top-level grouping
+- `description`: what this evidence type covers
+- `formats`: acceptable file formats
+- `usage_notes`: when to use this type vs. related types
+
+## Categories
+
+| Category | Description |
+|----------|-------------|
+| `document` | Written reports, plans, assessments, and declarations |
+| `geospatial` | Maps, satellite imagery, GIS data, boundary files |
+| `calculation` | Spreadsheets, formula workbooks, emissions/removals calculations |
+| `measurement` | Field measurements, sampling data, sensor readings |
+| `attestation` | Third-party statements, signatures, verification opinions |
+
+## Evidence types
+
+### document.monitoring_report
+
+| Field | Value |
+|-------|-------|
+| `id` | `monitoring_report` |
+| `display_name` | Monitoring Report |
+| `category` | `document` |
+| `description` | Periodic report describing project implementation, monitoring activities, and results against the monitoring plan |
+| `formats` | `pdf`, `docx` |
+| `usage_notes` | Use for rules requiring evidence of ongoing monitoring activities. Distinguish from `monitoring_plan` which is the plan document itself. |
+
+### document.monitoring_plan
+
+| Field | Value |
+|-------|-------|
+| `id` | `monitoring_plan` |
+| `display_name` | Monitoring Plan |
+| `category` | `document` |
+| `description` | The approved plan describing monitoring frequency, parameters, and methods |
+| `formats` | `pdf`, `docx` |
+| `usage_notes` | Use for rules requiring the monitoring methodology or plan document. Distinguish from `monitoring_report` which describes actual monitoring results. |
+
+### document.project_design_document
+
+| Field | Value |
+|-------|-------|
+| `id` | `pdd` |
+| `display_name` | Project Design Document (PDD) |
+| `category` | `document` |
+| `description` | The project design document describing project activities, baseline, additionality, and monitoring approach |
+| `formats` | `pdf`, `docx` |
+| `usage_notes` | Use for rules referencing PDD sections, project description, or baseline determination. |
+
+### document.project_description
+
+| Field | Value |
+|-------|-------|
+| `id` | `project_description` |
+| `display_name` | Project Description |
+| `category` | `document` |
+| `description` | Narrative description of the project, its location, technology, and activities |
+| `formats` | `pdf`, `docx` |
+| `usage_notes` | Use for rules specifically about project description content (distinct from PDD which is a broader document). |
+
+### document.baseline_report
+
+| Field | Value |
+|-------|-------|
+| `id` | `baseline_report` |
+| `display_name` | Baseline Report |
+| `category` | `document` |
+| `description` | Report documenting baseline emissions, baseline scenario, and baseline determination methodology |
+| `formats` | `pdf`, `xlsx`, `docx` |
+| `usage_notes` | Use for rules requiring baseline emissions evidence. May be part of PDD or a standalone document. |
+
+### document.additionality_assessment
+
+| Field | Value |
+|-------|-------|
+| `id` | `additionality_assessment` |
+| `display_name` | Additionality Assessment |
+| `category` | `document` |
+| `description` | Evidence demonstrating the project is additional (investment analysis, barrier analysis, common practice analysis) |
+| `formats` | `pdf`, `xlsx`, `docx` |
+| `usage_notes` | Use for additionality rules. Typically includes investment analysis spreadsheets and barrier analysis documentation. |
+
+### document.leakage_assessment
+
+| Field | Value |
+|-------|-------|
+| `id` | `leakage_assessment` |
+| `display_name` | Leakage Assessment |
+| `category` | `document` |
+| `description` | Analysis of potential leakage emissions outside the project boundary |
+| `formats` | `pdf`, `xlsx` |
+| `usage_notes` | Use for leakage quantification and prevention rules. |
+
+### document.emissions_reductions_calculation
+
+| Field | Value |
+|-------|-------|
+| `id` | `emissions_reductions_calculation` |
+| `display_name` | Emissions Reductions Calculation |
+| `category` | `document` |
+| `description` | Workbook or report showing ex-post emissions reductions or net GHG removals |
+| `formats` | `xlsx`, `pdf`, `csv` |
+| `usage_notes` | Use for rules requiring actual emissions reductions quantification. Distinguish from `calculation_workbook` which is a broader category. |
+
+### document.calculation_workbook
+
+| Field | Value |
+|-------|-------|
+| `id` | `calculation_workbook` |
+| `display_name` | Calculation Workbook |
+| `category` | `document` |
+| `description` | Spreadsheet containing formulas, input parameters, and intermediate calculations for GHG estimation |
+| `formats` | `xlsx`, `csv`, `numbers` |
+| `usage_notes` | Use for rules requiring traceable calculation logic. Includes any structured formula workbook used for quantification. |
+
+### document.validation_report
+
+| Field | Value |
+|-------|-------|
+| `id` | `validation_report` |
+| `display_name` | Validation Report |
+| `category` | `document` |
+| `description` | Third-party validation report confirming the project design meets applicable standards |
+| `formats` | `pdf` |
+| `usage_notes` | Use for rules referencing validation findings or requiring validation evidence. |
+
+### document.verification_report
+
+| Field | Value |
+|-------|-------|
+| `id` | `verification_report` |
+| `display_name` | Verification Report |
+| `category` | `document` |
+| `description` | Third-party verification report confirming emissions reductions or removals for a reporting period |
+| `formats` | `pdf` |
+| `usage_notes` | Use for rules referencing verification findings or requiring verified evidence. |
+
+### document.safeguards_report
+
+| Field | Value |
+|-------|-------|
+| `id` | `safeguards_report` |
+| `display_name` | Safeguards Report |
+| `category` | `document` |
+| `description` | Report documenting environmental and social safeguards, including stakeholder consultation and grievance mechanisms |
+| `formats` | `pdf`, `docx` |
+| `usage_notes` | Use for safeguards monitoring, stakeholder consultation, and sustainable development rules. Primarily relevant for Gold Standard methods. |
+
+### document.stakeholder_consultation
+
+| Field | Value |
+|-------|-------|
+| `id` | `stakeholder_consultation` |
+| `display_name` | Stakeholder Consultation Records |
+| `category` | `document` |
+| `description` | Records of stakeholder consultations, meetings, feedback, and responses |
+| `formats` | `pdf`, `docx` |
+| `usage_notes` | Use for rules requiring stakeholder engagement evidence. May include meeting minutes, sign-in sheets, and feedback logs. |
+
+### geospatial.project_boundary
+
+| Field | Value |
+|-------|-------|
+| `id` | `project_boundary` |
+| `display_name` | Project Boundary (GIS) |
+| `category` | `geospatial` |
+| `description` | Geospatial file defining the project boundary or area polygons |
+| `formats` | `geojson`, `shapefile`, `kml`, `gpkg` |
+| `usage_notes` | Use for rules requiring spatial definition of the project area. Must include coordinate reference system metadata. |
+
+### geospatial.satellite_imagery
+
+| Field | Value |
+|-------|-------|
+| `id` | `satellite_imagery` |
+| `display_name` | Satellite Imagery |
+| `category` | `geospatial` |
+| `description` | Satellite or aerial imagery of the project area for land cover, biomass, or activity data estimation |
+| `formats` | `geotiff`, `jp2`, `cloud-optimized-geotiff` |
+| `usage_notes` | Use for rules requiring remote sensing evidence. Typically referenced via STAC catalog entries. |
+
+### geospatial.land_cover_map
+
+| Field | Value |
+|-------|-------|
+| `id` | `land_cover_map` |
+| `display_name` | Land Cover / Land Use Map |
+| `category` | `geospatial` |
+| `description` | Classified land cover map derived from imagery or field surveys |
+| `formats` | `geotiff`, `geojson` |
+| `usage_notes` | Use for rules requiring land use classification or change detection evidence. |
+
+### geospatial.sampling_plot_locations
+
+| Field | Value |
+|-------|-------|
+| `id` | `sampling_plot_locations` |
+| `display_name` | Sampling Plot Locations |
+| `category` | `geospatial` |
+| `description` | Geospatial file defining field sampling plot locations |
+| `formats` | `geojson`, `shapefile`, `csv` |
+| `usage_notes` | Use for rules requiring stratified sampling or field measurement plot evidence. |
+
+### calculation.parameter_sheet
+
+| Field | Value |
+|-------|-------|
+| `id` | `parameter_sheet` |
+| `display_name` | Parameter Sheet |
+| `category` | `calculation` |
+| `description` | Structured listing of all parameters, defaults, sources, and values used in quantification |
+| `formats` | `xlsx`, `csv`, `json` |
+| `usage_notes` | Use for rules requiring ex-ante or ex-post parameter evidence. May be embedded in calculation workbook. |
+
+### calculation.emissions_factor
+
+| Field | Value |
+|-------|-------|
+| `id` | `emissions_factor` |
+| `display_name` | Emissions Factor |
+| `category` | `calculation` |
+| `description` | Published or derived emissions factor with source reference and uncertainty |
+| `formats` | `xlsx`, `csv`, `json` |
+| `usage_notes` | Use for rules referencing specific emission or removal factors. Must include source citation. |
+
+### measurement.field_data
+
+| Field | Value |
+|-------|-------|
+| `id` | `field_data` |
+| `display_name` | Field Measurement Data |
+| `category` | `measurement` |
+| `description` | Raw or processed field measurements including tree measurements, soil samples, biomass data |
+| `formats` | `xlsx`, `csv`, `json` |
+| `usage_notes` | Use for rules requiring in-situ field evidence. Must include measurement protocol and timestamp metadata. |
+
+### measurement.forest_inventory
+
+| Field | Value |
+|-------|-------|
+| `id` | `forest_inventory` |
+| `display_name` | Forest Inventory Data |
+| `category` | `measurement` |
+| `description` | Forest inventory data including species, diameter, height, and calculated biomass |
+| `formats` | `xlsx`, `csv`, `json` |
+| `usage_notes` | Use for forestry-specific rules requiring plot-level inventory evidence. |
+
+### attestation.legal_title
+
+| Field | Value |
+|-------|-------|
+| `id` | `legal_title` |
+| `display_name` | Legal Title / Land Tenure |
+| `category` | `attestation` |
+| `description` | Evidence of legal right to implement the project on the land area |
+| `formats` | `pdf`, `image` |
+| `usage_notes` | Use for rules requiring land tenure or legal right evidence. May include deeds, leases, or government approvals. |
+
+### attestation.authority_approval
+
+| Field | Value |
+|-------|-------|
+| `id` | `authority_approval` |
+| `display_name` | Authority Approval / Permit |
+| `category` | `attestation` |
+| `description` | Regulatory or government approval, permit, or letter of authorization |
+| `formats` | `pdf` |
+| `usage_notes` | Use for rules requiring government or regulatory approval evidence. |
+
+### attestation.certification
+
+| Field | Value |
+|-------|-------|
+| `id` | `certification` |
+| `display_name` | Certification Statement |
+| `category` | `attestation` |
+| `description` | Third-party certification, audit statement, or signed declaration |
+| `formats` | `pdf` |
+| `usage_notes` | Use for rules requiring signed attestation or certified statement evidence. |
+
+## Rule type to expected evidence mapping
+
+The following table maps rule types (from `rules.rich.json.type`) to the most common expected evidence types. This is a guideline, not a constraint — individual rules may deviate based on methodology-specific requirements.
+
+| Rule type | Common expected evidence types |
+|-----------|-------------------------------|
+| `eligibility` | `pdd`, `project_description`, `project_boundary`, `legal_title`, `authority_approval`, `certification` |
+| `parameter` | `parameter_sheet`, `calculation_workbook`, `emissions_factor`, `field_data`, `forest_inventory` |
+| `equation` | `calculation_workbook`, `emissions_reductions_calculation`, `parameter_sheet` |
+| `calc` | `calculation_workbook`, `emissions_reductions_calculation`, `parameter_sheet`, `emissions_factor` |
+| `monitoring` | `monitoring_report`, `monitoring_plan`, `satellite_imagery`, `land_cover_map`, `field_data` |
+| `leakage` | `leakage_assessment`, `calculation_workbook`, `project_boundary` |
+| `uncertainty` | `field_data`, `forest_inventory`, `calculation_workbook`, `parameter_sheet` |
+| `reporting` | `monitoring_report`, `verification_report`, `validation_report`, `safeguards_report` |
+
+## Extension protocol
+
+To add a new evidence type to the taxonomy:
+
+1. Propose the new type with the same structured fields (`id`, `display_name`, `category`, `description`, `formats`, `usage_notes`)
+2. Update `docs/standards/expected-evidence-taxonomy.md`
+3. Update the JSON Schema in `schemas/evidence-taxonomy.schema.json`
+4. Update any rules that should reference the new type
+5. Update the rule type mapping table if a new rule type is introduced
+
+New evidence types must not break existing `evidence_type_id` references. Always add; never remove or rename existing IDs without a migration path.

--- a/docs/standards/review-grade-method-pack-standard.md
+++ b/docs/standards/review-grade-method-pack-standard.md
@@ -1,0 +1,99 @@
+# Review-Grade Method Pack Standard
+
+A Review-Grade methodology pack is one that meets all Source-Audited requirements **and** exposes complete, machine-readable expected evidence metadata for every rule.
+
+Review-Grade is the formal superset of Source-Audited. Every Review-Grade method is also Source-Audited; not every Source-Audited method is Review-Grade.
+
+The app displays a `Review-Grade` badge for methodology packs meeting this standard and uses the evidence metadata to drive evidence pickers, review panels, and export composers.
+
+## Requirements
+
+### Source-Audited baseline
+
+A Review-Grade method must meet every requirement of the Source-Audited Methodology Standard:
+- Source PDF verified
+- All sections source-audited
+- All rules source-audited (no `draft_unverified`, no active blockers)
+- `methodology_linked_review_ready: true`
+
+### Expected evidence completeness
+
+Every rule in the method pack must have `requirement_coverage.expected_evidence` populated:
+
+- `expected_evidence[]` is non-empty for every rule
+- Each entry references a valid `evidence_type_id` from the published evidence taxonomy
+- Each entry has a non-empty `evidence_kind` (`mandatory`, `optional`, `conditional`)
+- `conditional` entries include a machine-readable `evidence_condition`
+- Each entry has a non-empty `description` string (no placeholder text)
+
+### Evidence taxonomy conformance
+
+- All `evidence_type_id` values resolve to entries in `docs/standards/expected-evidence-taxonomy.md`
+- No custom or invented evidence types outside the taxonomy
+- Taxonomy extensions must follow the extension protocol (new type added to taxonomy before being referenced)
+
+### Requirement kind completeness
+
+Every rule must have `requirement_kind` populated:
+- `human-judgment-required` — rule requires reviewer expertise (e.g., additionality论证)
+- `calculable` — rule can be verified via calculation workbook fields
+- `document-check` — rule is satisfied by document presence (e.g., monitoring plan exists)
+
+### Metadata (META.json)
+
+- `artifact_quality_standard.adoption_status: "review_grade"`
+- `artifact_quality_standard.version: "review_contract_v2"` (or later)
+- `methodology_linked_review_ready: true`
+- All Source-Audited META fields present and truthful
+- `export.evidence_intelligence_version` matches the app consumption contract version
+
+### Determinism
+
+- Same input source → same expected_evidence output (bytes-identical)
+- Evidence metadata is generated deterministically from methodology rules and source spans
+- No random, date-stamped, or reviewer-dependent evidence entries
+
+### CI verification gates
+
+CI must verify that Review-Grade methods satisfy all of the above. A failing gate demotes the method to `not_grade_a` (Source-Audited baseline) until resolved.
+
+## Compatibility
+
+| Public standard | Internal machine value | Superset of |
+|----------------|------------------------|-------------|
+| Review-Grade | `adoption_status: "review_grade"` | Source-Audited |
+| Source-Audited | `adoption_status: "grade_a"` | — |
+| Not Source-Audited | `adoption_status: "not_grade_a"` | — |
+
+The `review_grade` value is new. Existing Source-Audited methods retain `grade_a` until promoted.
+
+## Transition path
+
+A Source-Audited method reaches Review-Grade by:
+1. Populating `requirement_coverage.expected_evidence` for every rule using the published taxonomy
+2. Setting `requirement_kind` for every rule
+3. Updating `META.artifact_quality_standard.adoption_status` to `"review_grade"`
+4. Adding `META.export.evidence_intelligence_version`
+5. Passing all Review-Grade CI gates
+
+## Verification
+
+```bash
+node scripts/check-method-grade.js methodologies/<Standard>/<Program>/<Code>/<version>
+```
+
+The validator checks:
+- Source-Audited baseline pass
+- Every rule has non-empty `expected_evidence[]`
+- All `evidence_type_id` values resolve in the taxonomy
+- All `requirement_kind` values are valid
+- META.json adoption_status matches actual state
+- CI gate results
+
+## Scope
+
+This standard defines methodology pack quality only. It does not imply:
+- VVB approval, certification, validation, or verification
+- Carbon credit quality or eligibility
+- Regulatory or programmatic endorsement
+- Evidence sufficiency (whether the expected evidence is sufficient for a real review)


### PR DESCRIPTION
## WHAT

- Create the `review-grade-evidence-intelligence` roadmap in `article6-methodologies`.
- Add roadmap document at `docs/roadmaps/review-grade-evidence-intelligence/ROADMAP.md`.
- Add roadmap SSOT file at `docs/roadmaps/review-grade-evidence-intelligence/phase-status.json`.
- Add `docs/standards/review-grade-method-pack-standard.md`.
- Add `docs/standards/expected-evidence-taxonomy.md`.
- Define the initial evidence taxonomy for review-grade methodology packs.
- **Keep this as a documentation and schema-planning PR only**; do not change runtime generation logic yet.

## WHY

- Article6 needs a formal standard for methodology packs before app-side extraction and exports can become reliable.
- Expected evidence metadata is the foundation for deterministic evidence linking.
- The methodologies repo should define what each rule requires, while the app repo handles project uploads, extraction, review, and export rendering.

## Files

| File | Purpose |
|------|---------|
| `docs/roadmaps/review-grade-evidence-intelligence/ROADMAP.md` | Narrative with 6 phases (RGEI-S1 through RGEI-S6), scope, and delivery constraints |
| `docs/roadmaps/review-grade-evidence-intelligence/phase-status.json` | SSOT — all phases at `not_started` |
| `docs/standards/review-grade-method-pack-standard.md` | Review-Grade as formal superset of Source-Audited + expected evidence completeness |
| `docs/standards/expected-evidence-taxonomy.md` | 22 evidence types across 5 categories with rule-type mapping table |

## Design

- **Review-Grade** = Source-Audited baseline + complete expected evidence metadata per rule
- **Phase IDs** follow repo convention: `rgei-s1` through `rgei-s6`
- **Taxonomy** aligned with existing `rules.rich.schema.json` `expected_evidence` shape
- **No runtime schemas or methodology artifacts changed**

Signed-off-by: Fred Egbuedike <fredilly@article6.org